### PR TITLE
Unngå feilrapportering av antall eventer på topics

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbe.kt
@@ -12,12 +12,7 @@ class TopicMetricsProbe(private val metricsReporter: MetricsReporter,
 
     private val log = LoggerFactory.getLogger(TopicMetricsProbe::class.java)
 
-    private val lastReportedUniqueEvents = mutableMapOf<EventType, Int>().apply {
-        put(EventType.BESKJED, 0)
-        put(EventType.INNBOKS, 0)
-        put(EventType.OPPGAVE, 0)
-        put(EventType.DONE, 0)
-    }
+    private val lastReportedUniqueEvents = HashMap<EventType, Int>()
 
     suspend fun runWithMetrics(eventType: EventType, block: suspend TopicMetricsSession.() -> Unit) {
         val session = TopicMetricsSession(eventType)


### PR DESCRIPTION
Fiks for å ikke rapportere metrikker til Influx i tilfeller hvor det har blitt telt feil antall eventer på en topic.

Antall eventer på topic-ene skal øke eller holde seg konstant, denne fiksen benytter seg av dette og rapporterer kun metrikker hvis antallet unike eventer er lik eller høyrere enn ved forrige telling. Det vil fjerne de fleste feilrapporteringene, unntatt hvis første telling etter en deploy teller feil. Men det er nok det minst sannsynlige tidspunket for tellefeil, fordi den har en helt fersk kafka-klient.

Dette er en litt hack-ete løsning, men vi kan se om den fungerer godt nok.