### PR TITLE
Rettet en bug som gjorde at det var mulig å 0 som en gyldig telling av eventer

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbe.kt
@@ -35,8 +35,10 @@ class TopicMetricsProbe(private val metricsReporter: MetricsReporter,
         }
     }
 
-    private fun countedMoreEventsThanLastCount(session: TopicMetricsSession, eventType: EventType) =
-            session.getNumberOfUniqueEvents() >= lastReportedUniqueEvents.getOrDefault(eventType, 0)
+    private fun countedMoreEventsThanLastCount(session: TopicMetricsSession, eventType: EventType): Boolean {
+        val currentCount = session.getNumberOfUniqueEvents()
+        return currentCount > 0 && currentCount >= lastReportedUniqueEvents.getOrDefault(eventType, 0)
+    }
 
     private suspend fun handleUniqueEvents(session: TopicMetricsSession) {
         val uniqueEvents = session.getNumberOfUniqueEvents()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
@@ -145,7 +145,7 @@ internal class TopicMetricsProbeTest {
 
         runBlocking {
             metricsProbe.runWithMetrics(EventType.BESKJED) {
-
+                // Triggers uten at det blir rapportert noen eventer, for å simulere en feiltelling.
             }
         }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
@@ -131,6 +131,32 @@ internal class TopicMetricsProbeTest {
         verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(3, any(), any()) }
     }
 
+    @Test
+    fun `Should not report metrics if current count is zero`() {
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+        val nameScrubber = ProducerNameScrubber(producerNameResolver)
+        val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
+
+        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, any(), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
+
+        runBlocking {
+            metricsProbe.runWithMetrics(EventType.BESKJED) {
+
+            }
+        }
+
+        val numberOfSuccessfulCountingSessions = 0
+        coVerify(exactly = numberOfSuccessfulCountingSessions) { metricsReporter.registerDataPoint(any(), any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEvents(any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEvents(any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(any(), any(), any()) }
+    }
+
     private fun `sesjon som teller tre eventer`(metricsProbe: TopicMetricsProbe) = runBlocking {
         metricsProbe.runWithMetrics(EventType.BESKJED) {
             countEvent(UniqueKafkaEventIdentifier("1", "producer", "123"))


### PR DESCRIPTION
Antallet eventer på topic-ene som telles skal kun øke, og en telling ender med 0 så indikerer det en tellefeil.