### PR TITLE
Senker loggnivået for eventer som ikke har alias for systembruker

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/ProducerNameResolver.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/ProducerNameResolver.kt
@@ -25,7 +25,7 @@ class ProducerNameResolver(private val database: Database) {
                 updateCache()
             }
             if(!containsAlias) {
-                log.warn("Manglet alias for oppgitt systembruker, forsøker å oppdatere cache på nytt.")
+                log.info("Manglet alias for oppgitt systembruker, forsøker å oppdatere cache på nytt.")
             }
         }
         return producerNameAliases[systembruker]


### PR DESCRIPTION
Denne appen leser alle eventer på nytt hele tiden, og derfor er ikke dette en feilsituasjon. Det er `dittnav-event-aggregator` sin oppgave å rapportere nye eventer som mangler alias-mapping.