### PR TITLE
Metrikker for hvor lang tid det tar å telle hver eventtype fra cache og topic

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/PrometheusMetricsCollector.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/PrometheusMetricsCollector.kt
@@ -15,6 +15,7 @@ object PrometheusMetricsCollector {
     private const val KAFKA_TOPIC_COUNT_PROCESSING_TIME = "kafka_topic_count_processing_time"
     private const val DB_TOTAL_EVENTS = "db_total_events"
     private const val DB_TOTAL_EVENTS_BY_PRODUCER = "db_total_events_by_producer"
+    private const val DB_COUNT_PROCESSING_TIME = "db_count_processing_time"
 
     private val MESSAGES_UNIQUE: Gauge = Gauge.build()
             .name(KAFKA_TOPIC_UNIQUE_EVENTS)
@@ -72,6 +73,13 @@ object PrometheusMetricsCollector {
             .labelNames("type", "producer")
             .register()
 
+    private val CACHED_COUNT_PROCESSING_TIME: Gauge = Gauge.build()
+        .name(DB_COUNT_PROCESSING_TIME)
+        .namespace(NAMESPACE)
+        .help("Time used to count events of this type in nanoseconds")
+        .labelNames("type")
+        .register()
+
     fun registerUniqueEvents(count: Int, eventType: EventType) {
         MESSAGES_UNIQUE.labels(eventType.eventType).set(count.toDouble())
     }
@@ -102,6 +110,10 @@ object PrometheusMetricsCollector {
 
     fun registerTotalNumberOfEventsInCacheByProducer(count: Int, eventType: EventType, producer: String) {
         CACHED_EVENTS_IN_TOTAL_BY_PRODUCER.labels(eventType.eventType, producer).set(count.toDouble())
+    }
+
+    fun registerProcessingTimeInCache(processingTime: Long, eventType: EventType) {
+        CACHED_COUNT_PROCESSING_TIME.labels(eventType.eventType).set(processingTime.toDouble())
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/PrometheusMetricsCollector.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/PrometheusMetricsCollector.kt
@@ -5,15 +5,16 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 
 object PrometheusMetricsCollector {
 
-    const val NAMESPACE = "dittnav_consumer"
+    private const val NAMESPACE = "dittnav_consumer"
 
-    const val KAFKA_TOPIC_TOTAL_EVENTS = "kafka_topic_total_events"
-    const val KAFKA_TOPIC_TOTAL_EVENTS_BY_PRODUCER = "kafka_topic_total_events_by_producer"
-    const val KAFKA_TOPIC_UNIQUE_EVENTS = "kafka_topic_unique_events"
-    const val KAFKA_TOPIC_UNIQUE_EVENTS_BY_PRODUCER = "kafka_topic_unique_events_by_producer"
-    const val KAFKA_TOPIC_DUPLICATED_EVENTS = "kafka_topic_duplicated_events"
-    const val DB_TOTAL_EVENTS = "db_total_events"
-    const val DB_TOTAL_EVENTS_BY_PRODUCER = "db_total_events_by_producer"
+    private const val KAFKA_TOPIC_TOTAL_EVENTS = "kafka_topic_total_events"
+    private const val KAFKA_TOPIC_TOTAL_EVENTS_BY_PRODUCER = "kafka_topic_total_events_by_producer"
+    private const val KAFKA_TOPIC_UNIQUE_EVENTS = "kafka_topic_unique_events"
+    private const val KAFKA_TOPIC_UNIQUE_EVENTS_BY_PRODUCER = "kafka_topic_unique_events_by_producer"
+    private const val KAFKA_TOPIC_DUPLICATED_EVENTS = "kafka_topic_duplicated_events"
+    private const val KAFKA_TOPIC_COUNT_PROCESSING_TIME = "kafka_topic_count_processing_time"
+    private const val DB_TOTAL_EVENTS = "db_total_events"
+    private const val DB_TOTAL_EVENTS_BY_PRODUCER = "db_total_events_by_producer"
 
     private val MESSAGES_UNIQUE: Gauge = Gauge.build()
             .name(KAFKA_TOPIC_UNIQUE_EVENTS)
@@ -34,6 +35,13 @@ object PrometheusMetricsCollector {
             .namespace(NAMESPACE)
             .help("Number of duplicated events of type on topic")
             .labelNames("type", "producer")
+            .register()
+
+    private val MESSAGES_COUNT_PROCESSING_TIME: Gauge = Gauge.build()
+            .name(KAFKA_TOPIC_COUNT_PROCESSING_TIME)
+            .namespace(NAMESPACE)
+            .help("Time used to count events of this type in nanoseconds")
+            .labelNames("type")
             .register()
 
     private val MESSAGES_TOTAL: Gauge = Gauge.build()
@@ -82,6 +90,10 @@ object PrometheusMetricsCollector {
 
     fun registerTotalNumberOfEventsByProducer(count: Int, eventType: EventType, producer: String) {
         MESSAGES_TOTAL_BY_PRODUCER.labels(eventType.eventType, producer).set(count.toDouble())
+    }
+
+    fun registerProcessingTime(processingTime: Long, eventType: EventType) {
+        MESSAGES_COUNT_PROCESSING_TIME.labels(eventType.eventType).set(processingTime.toDouble())
     }
 
     fun registerTotalNumberOfEventsInCache(count: Int, eventType: EventType) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbe.kt
@@ -4,22 +4,28 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_COUNT_PROCESSING_TIME
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
 import org.slf4j.LoggerFactory
 
-class DbCountingMetricsProbe(private val metricsReporter: MetricsReporter,
-                             private val nameScrubber: ProducerNameScrubber) {
+class DbCountingMetricsProbe(
+    private val metricsReporter: MetricsReporter,
+    private val nameScrubber: ProducerNameScrubber
+) {
 
     private val log = LoggerFactory.getLogger(DbCountingMetricsProbe::class.java)
 
     suspend fun runWithMetrics(eventType: EventType, block: suspend DbCountingMetricsSession.() -> Unit) {
+        val start = System.nanoTime()
         val session = DbCountingMetricsSession(eventType)
         block.invoke(session)
+        val processingTime = System.nanoTime() - start
 
         if (session.getProducers().isNotEmpty()) {
             handleTotalEvents(session)
             handleTotalEventsByProducer(session)
+            reportTimeUsed(session, processingTime)
         }
     }
 
@@ -38,8 +44,17 @@ class DbCountingMetricsProbe(private val metricsReporter: MetricsReporter,
             val printableAlias = nameScrubber.getPublicAlias(producerName)
 
             reportEvents(numberOfEvents, eventTypeName, printableAlias, DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER)
-            PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(numberOfEvents, session.eventType, printableAlias)
+            PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(
+                numberOfEvents,
+                session.eventType,
+                printableAlias
+            )
         }
+    }
+
+    private suspend fun reportTimeUsed(session: DbCountingMetricsSession, processingTime: Long) {
+        reportProcessingTimeEvent(processingTime, session)
+        PrometheusMetricsCollector.registerProcessingTimeInCache(processingTime, session.eventType)
     }
 
     private suspend fun reportEvents(count: Int, eventType: String, producerAlias: String, metricName: String) {
@@ -48,14 +63,24 @@ class DbCountingMetricsProbe(private val metricsReporter: MetricsReporter,
 
     private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
 
+    private fun counterField(events: Long): Map<String, Long> = listOf("counter" to events).toMap()
+
     private fun createTagMap(eventType: String, producer: String): Map<String, String> =
-            listOf("eventType" to eventType, "producer" to producer).toMap()
+        listOf("eventType" to eventType, "producer" to producer).toMap()
 
     private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
         metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))
     }
 
+    private suspend fun reportProcessingTimeEvent(processingTime: Long, session: DbCountingMetricsSession) {
+        val metricName = DB_COUNT_PROCESSING_TIME
+        metricsReporter.registerDataPoint(
+            metricName, counterField(processingTime),
+            createTagMap(session.eventType.eventType)
+        )
+    }
+
     private fun createTagMap(eventType: String): Map<String, String> =
-            listOf("eventType" to eventType).toMap()
+        listOf("eventType" to eventType).toMap()
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/influx/metricNames.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/influx/metricNames.kt
@@ -9,3 +9,4 @@ const val KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER = "$METRIC_NAMESPACE.topic.pro
 const val KAFKA_UNIQUE_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.aggregated.unique"
 const val KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER = "$METRIC_NAMESPACE.topic.producer.unique"
 const val KAFKA_DUPLICATE_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.duplicates"
+const val KAFKA_COUNT_PROCESSING_TIME = "$METRIC_NAMESPACE.topic.count.processing.time"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/influx/metricNames.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/influx/metricNames.kt
@@ -4,6 +4,8 @@ private const val METRIC_NAMESPACE = "dittnav.kafka.events.v1"
 
 const val DB_TOTAL_EVENTS_IN_CACHE = "$METRIC_NAMESPACE.db.aggregated.total"
 const val DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER = "$METRIC_NAMESPACE.db.producer.total"
+const val DB_COUNT_PROCESSING_TIME = "$METRIC_NAMESPACE.db.count.processing.time"
+
 const val KAFKA_TOTAL_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.aggregated.total"
 const val KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER = "$METRIC_NAMESPACE.topic.producer.total"
 const val KAFKA_UNIQUE_EVENTS_ON_TOPIC = "$METRIC_NAMESPACE.topic.aggregated.unique"

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbeTest.kt
@@ -58,7 +58,7 @@ internal class DbCountingMetricsProbeTest {
     }
 
     @Test
-    fun `Should report the elapsed to count the events`() {
+    fun `Should report the elapsed time to count the events`() {
         val expectedProcessingTimeMs = 100L
         val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbeTest.kt
@@ -1,23 +1,26 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
 
 import io.mockk.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_COUNT_PROCESSING_TIME
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
 import org.amshove.kluent.`should equal`
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeLessThan
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class DbCountingMetricsProbeTest {
 
-    private val metricsReporter = mockk<MetricsReporter>()
+    private val metricsReporter = mockk<MetricsReporter>(relaxed = true)
     private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
-    private val producerNameResolver = mockk<ProducerNameResolver>()
+    private val producerNameResolver = mockk<ProducerNameResolver>(relaxed = true)
 
     @BeforeEach
     fun cleanup() {
@@ -37,7 +40,6 @@ internal class DbCountingMetricsProbeTest {
 
         val capturedTotalEventsInCacheByProducer = slot<Map<String, Any>>()
 
-        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE, any(), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, capture(capturedTotalEventsInCacheByProducer), any()) } returns Unit
 
         runBlocking {
@@ -46,12 +48,43 @@ internal class DbCountingMetricsProbeTest {
             }
         }
 
-        coVerify(exactly = 3) { metricsReporter.registerDataPoint(any(), any(), any()) }
+        coVerify(exactly = 4) { metricsReporter.registerDataPoint(any(), any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(3, any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(1, any(), any()) }
         verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(2, any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerProcessingTimeInCache(any(), any()) }
 
         capturedTotalEventsInCacheByProducer.captured["counter"] `should equal` 1
+    }
+
+    @Test
+    fun `Should report the elapsed to count the events`() {
+        val expectedProcessingTimeMs = 100L
+        val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
+
+        val dummyCountResultFromDb = mutableMapOf<String, Int>().apply {
+            put("produsent1", 1)
+            put("produsent2", 2)
+        }
+
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+        val nameScrubber = ProducerNameScrubber(producerNameResolver)
+        val topicMetricsProbe = DbCountingMetricsProbe(metricsReporter, nameScrubber)
+
+        val capturedProcessingTime = slot<Map<String, Long>>()
+
+        coEvery { metricsReporter.registerDataPoint(DB_COUNT_PROCESSING_TIME, capture(capturedProcessingTime), any()) } returns Unit
+
+        runBlocking {
+            topicMetricsProbe.runWithMetrics(EventType.BESKJED) {
+                addEventsByProducer(dummyCountResultFromDb)
+                delay(expectedProcessingTimeMs)
+            }
+        }
+
+        capturedProcessingTime.captured["counter"]!!.shouldBeGreaterOrEqualTo(expectedProcessingTimeNs)
+        val twentyPercentMoreThanExpectedTime  = (expectedProcessingTimeNs * 1.2).toLong()
+        capturedProcessingTime.captured["counter"]!!.shouldBeLessThan(twentyPercentMoreThanExpectedTime)
     }
 
     @Test
@@ -66,7 +99,6 @@ internal class DbCountingMetricsProbeTest {
         val producerNameForPrometheus = slot<String>()
         val capturedTagsForTotalByProducer = slot<Map<String, String>>()
 
-        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE, any(), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
         every { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(any(), any(), capture(producerNameForPrometheus)) } returns Unit
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
@@ -69,7 +69,7 @@ internal class TopicMetricsProbeTest {
     }
 
     @Test
-    fun `Should report the elapsed to count the events`() {
+    fun `Should report the elapsed time to count the events`() {
         val expectedProcessingTimeMs = 100L
         val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.Test
 
 internal class TopicMetricsProbeTest {
 
-    private val metricsReporter = mockk<MetricsReporter>()
+    private val metricsReporter = mockk<MetricsReporter>(relaxed = true)
     private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
-    private val producerNameResolver = mockk<ProducerNameResolver>()
+    private val producerNameResolver = mockk<ProducerNameResolver>(relaxed = true)
 
     @BeforeEach
     fun cleanup() {
@@ -40,7 +40,6 @@ internal class TopicMetricsProbeTest {
         val capturedFieldsForTotalEventsByProducer = slot<Map<String, Any>>()
 
         coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, capture(capturedFieldsForUnique), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, any(), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, capture(capturedFieldsForTotalEvents), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, capture(capturedFieldsForDuplicated), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, capture(capturedFieldsForTotalEventsByProducer), any()) } returns Unit
@@ -80,11 +79,6 @@ internal class TopicMetricsProbeTest {
 
         val capturedFieldsForProcessingTime = slot<Map<String, Long>>()
 
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, capture(capturedFieldsForProcessingTime), any()) } returns Unit
 
         runBlocking {
@@ -114,9 +108,6 @@ internal class TopicMetricsProbeTest {
         val capturedTagsForTotalByProducer = slot<Map<String, String>>()
 
         every { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), capture(producerNameForPrometheus)) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), capture(capturedTagsForDuplicates)) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
         coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForUniqueByProducer)) } returns Unit
@@ -148,13 +139,6 @@ internal class TopicMetricsProbeTest {
         val nameScrubber = ProducerNameScrubber(producerNameResolver)
         val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
 
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
-
         `sesjon som teller tre eventer`(metricsProbe)
         `sesjon som feilaktig teller to eventer`(metricsProbe)
         `sesjon som teller tre eventer`(metricsProbe)
@@ -172,13 +156,6 @@ internal class TopicMetricsProbeTest {
         coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
         val nameScrubber = ProducerNameScrubber(producerNameResolver)
         val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
-
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) } returns Unit
 
         runBlocking {
             metricsProbe.runWithMetrics(EventType.BESKJED) {


### PR DESCRIPTION
Dataene er visualisert nederst [i dette boardet](https://grafana.adeo.no/d/ZpeXY3mGz/dittnav-brukernotifikasjoner?orgId=1&refresh=1m&from=now-1h&to=now&var-env=dev&var-cluster=dev-sbs&var-cluster_fss=dev-fss&var-namespace=personbruker&var-event_type=All).