### PR TITLE
Bytter til en raskere spørring for å telle antall eventer per produsent.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/metricsQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/metricsQueries.kt
@@ -31,11 +31,22 @@ fun Connection.countTotalNumberOfEventsByActiveStatus(eventType: EventType, akti
 
 fun Connection.countTotalNumberOfBrukernotifikasjonerByActiveStatus(aktiv: Boolean): Map<String, Int> {
     return prepareStatement(
-            "SELECT systembruker, COUNT(*) FROM brukernotifikasjon_view WHERE aktiv = ? GROUP BY systembruker;",
+"""SELECT
+                subquery.systembruker, sum(count)
+        FROM (
+             SELECT systembruker, COUNT(1) as count FROM BESKJED WHERE aktiv = ? GROUP BY systembruker
+             UNION ALL
+             SELECT systembruker, COUNT(1) as count FROM OPPGAVE WHERE aktiv = ? GROUP BY systembruker
+             UNION ALL
+             SELECT systembruker, COUNT(1) as count FROM INNBOKS WHERE aktiv = ? GROUP BY systembruker
+        ) as subquery group by subquery.systembruker order by subquery.systembruker;
+    """,
             ResultSet.TYPE_SCROLL_INSENSITIVE,
             ResultSet.CONCUR_READ_ONLY)
             .use { statement ->
                 statement.setBoolean(1, aktiv)
+                statement.setBoolean(2, aktiv)
+                statement.setBoolean(3, aktiv)
                 val resultSet = statement.executeQuery()
                 mutableMapOf<String, Int>().apply {
                     while (resultSet.next()) {


### PR DESCRIPTION
@chris-santa sin nye spørring, som dropper å gå mot brukernotifikasjon-view-et.

Alle de gamle testene passerer, og det ser riktig ut ved manuell kjøring mot reelle tabeller ved å sammenligne gammel og ny spørring.

Oppdateringen er å vei ut i dev (personbruker).