### PR TITLE
Robustifisert tellingen av eventer

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceIT.kt
@@ -11,7 +11,6 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.KafkaConsumerSetup.createCountConsumer
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.nokkel.createNokkel
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.shouldEqualTo
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.junit.jupiter.api.AfterAll
@@ -51,7 +50,7 @@ class TopicEventCounterServiceIT {
         val service = TopicEventCounterService(metricsProbe, beskjedCountConsumer, innboksCountConsumer, oppgaveCountConsumer, doneCountConsumer)
 
         runBlocking {
-            service.countAndReportMetricsForBeskjeder()
+            service.countBeskjeder()
         }
 
         metricsSession.getDuplicates() `should be equal to` events.size * 2
@@ -87,7 +86,7 @@ class TopicEventCounterServiceIT {
 
     private fun `tell og verifiser korrekt antall eventer`(service: TopicEventCounterService, metricsSession: TopicMetricsSession) {
         runBlocking {
-            service.countAndReportMetricsForBeskjeder()
+            service.countBeskjeder()
         }
 
         metricsSession.getNumberOfUniqueEvents() `should be equal to` events.size
@@ -99,13 +98,14 @@ class TopicEventCounterServiceIT {
             val fikkProduserBatch2 = KafkaTestUtil.produceEvents(testEnvironment, topicen, events)
             val fikkProduserBatch3 = KafkaTestUtil.produceEvents(testEnvironment, topicen, events)
             fikkProduserBatch1 && fikkProduserBatch2 && fikkProduserBatch3
-        } shouldEqualTo true
+        } `should be equal to` true
     }
 
     private fun `Sorg for at metrics session trigges`(metricsProbe: TopicMetricsProbe, metricsSession: TopicMetricsSession) {
         val slot = slot<suspend TopicMetricsSession.() -> Unit>()
         coEvery { metricsProbe.runWithMetrics(any(), capture(slot)) } coAnswers {
             slot.captured.invoke(metricsSession)
+            metricsSession
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/exceptions/CountException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/exceptions/CountException.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions
+
+class CountException (message: String, cause: Throwable?) : AbstractPersonbrukerException(message, cause) {
+    constructor(message: String) : this(message, null)
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/exceptions/MetricsReportingException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/exceptions/MetricsReportingException.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions
+
+class MetricsReportingException (message: String, cause: Throwable?) : AbstractPersonbrukerException(message, cause) {
+    constructor(message: String) : this(message, null)
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
@@ -2,16 +2,18 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.config
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.database.Database
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.HealthService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.buildDbEventCountingMetricsProbe
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.buildTopicMetricsProbe
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.CacheEventCounterService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.MetricsRepository
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.*
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.KafkaEventCounterService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.KafkaTopicEventCounterService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.closeConsumer
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.createCountConsumer
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsProbe
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.resolveMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter.MetricsSubmitterService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter.PeriodicMetricsSubmitter
 import org.apache.avro.generic.GenericRecord
 import org.slf4j.LoggerFactory
@@ -27,31 +29,43 @@ class ApplicationContext {
 
     val kafkaTopicEventCounterService = KafkaTopicEventCounterService(environment)
 
+    val nameResolver = ProducerNameResolver(database)
+    val nameScrubber = ProducerNameScrubber(nameResolver)
+    val metricsReporter = resolveMetricsReporter(environment)
+
     val metricsRepository = MetricsRepository(database)
     val cacheEventCounterService = CacheEventCounterService(environment, metricsRepository)
-    val dbEventCountingMetricsProbe = buildDbEventCountingMetricsProbe(environment, database)
+    val dbEventCountingMetricsProbe = DbCountingMetricsProbe()
     val dbEventCounterService = DbEventCounterService(dbEventCountingMetricsProbe, metricsRepository)
+    val dbMetricsReporter = DbMetricsReporter(metricsReporter, nameScrubber)
 
-    val topicMetricsProbe = buildTopicMetricsProbe(environment, database)
+    val topicMetricsProbe = TopicMetricsProbe()
+    val kafkaMetricsReporter = TopicMetricsReporter(metricsReporter, nameScrubber)
 
     val beskjedCountConsumer = createCountConsumer<GenericRecord>(EventType.BESKJED, Kafka.beskjedTopicName, environment)
     val innboksCountConsumer = createCountConsumer<GenericRecord>(EventType.INNBOKS, Kafka.innboksTopicName, environment)
     val oppgaveCountConsumer = createCountConsumer<GenericRecord>(EventType.OPPGAVE, Kafka.oppgaveTopicName, environment)
     val doneCountConsumer = createCountConsumer<GenericRecord>(EventType.DONE, Kafka.doneTopicName, environment)
     val topicEventCounterService = TopicEventCounterService(
-            topicMetricsProbe = topicMetricsProbe,
-            beskjedCountConsumer = beskjedCountConsumer,
-            innboksCountConsumer = innboksCountConsumer,
-            oppgaveCountConsumer = oppgaveCountConsumer,
-            doneCountConsumer = doneCountConsumer
+        topicMetricsProbe = topicMetricsProbe,
+        beskjedCountConsumer = beskjedCountConsumer,
+        innboksCountConsumer = innboksCountConsumer,
+        oppgaveCountConsumer = oppgaveCountConsumer,
+        doneCountConsumer = doneCountConsumer
     )
     val kafkaEventCounterService = KafkaEventCounterService(
-            beskjedCountConsumer = beskjedCountConsumer,
-            innboksCountConsumer = innboksCountConsumer,
-            oppgaveCountConsumer = oppgaveCountConsumer,
-            doneCountConsumer = doneCountConsumer
+        beskjedCountConsumer = beskjedCountConsumer,
+        innboksCountConsumer = innboksCountConsumer,
+        oppgaveCountConsumer = oppgaveCountConsumer,
+        doneCountConsumer = doneCountConsumer
     )
 
+    val metricsSubmitterService = MetricsSubmitterService(
+        dbEventCounterService,
+        topicEventCounterService,
+        dbMetricsReporter,
+        kafkaMetricsReporter
+    )
     var periodicMetricsSubmitter = initializePeriodicMetricsSubmitter()
 
     fun reinitializePeriodicMetricsSubmitter() {
@@ -64,7 +78,7 @@ class ApplicationContext {
     }
 
     private fun initializePeriodicMetricsSubmitter(): PeriodicMetricsSubmitter =
-            PeriodicMetricsSubmitter(dbEventCounterService, topicEventCounterService)
+        PeriodicMetricsSubmitter(metricsSubmitterService)
 
     fun closeAllConsumers() {
         closeConsumer(beskjedCountConsumer)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
@@ -1,0 +1,38 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+
+class CountingMetricsSessions {
+
+    private val sessions = mutableMapOf<EventType, CountingMetricsSession>()
+
+    fun put(eventType: EventType, session: CountingMetricsSession) {
+        sessions[eventType] = session
+    }
+
+    fun totalUniqueEvents(): Int {
+        var total = 0
+        sessions.forEach { (eventType: EventType, session: CountingMetricsSession) ->
+            total += session.getNumberOfUniqueEvents()
+        }
+        return total
+    }
+
+    fun getEventTypesWithSession(): Set<EventType> {
+        return sessions.keys
+    }
+
+    fun getForType(eventType: EventType): CountingMetricsSession {
+        return sessions[eventType]
+            ?: throw Exception("Det finnes ingen sesjon for '$eventType'.")
+    }
+
+    override fun toString(): String {
+        return "CountingMetricsSessions(sessions=$sessions)"
+    }
+
+}
+
+interface CountingMetricsSession {
+    fun getNumberOfUniqueEvents(): Int
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
@@ -12,7 +12,7 @@ class CountingMetricsSessions {
 
     fun totalUniqueEvents(): Int {
         var total = 0
-        sessions.forEach { (eventType: EventType, session: CountingMetricsSession) ->
+        sessions.forEach { (_, session: CountingMetricsSession) ->
             total += session.getNumberOfUniqueEvents()
         }
         return total

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbe.kt
@@ -1,86 +1,17 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_COUNT_PROCESSING_TIME
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
 import org.slf4j.LoggerFactory
 
-class DbCountingMetricsProbe(
-    private val metricsReporter: MetricsReporter,
-    private val nameScrubber: ProducerNameScrubber
-) {
+class DbCountingMetricsProbe {
 
     private val log = LoggerFactory.getLogger(DbCountingMetricsProbe::class.java)
 
-    suspend fun runWithMetrics(eventType: EventType, block: suspend DbCountingMetricsSession.() -> Unit) {
-        val start = System.nanoTime()
+    suspend fun runWithMetrics(eventType: EventType, block: suspend DbCountingMetricsSession.() -> Unit): DbCountingMetricsSession {
         val session = DbCountingMetricsSession(eventType)
         block.invoke(session)
-        val processingTime = System.nanoTime() - start
-
-        if (session.getProducers().isNotEmpty()) {
-            handleTotalEvents(session)
-            handleTotalEventsByProducer(session)
-            reportTimeUsed(session, processingTime)
-        }
+        session.calculateProcessingTime()
+        return session
     }
-
-    private suspend fun handleTotalEvents(session: DbCountingMetricsSession) {
-        val numberOfEvents = session.getTotalNumber()
-        val eventTypeName = session.eventType.toString()
-
-        reportEvents(numberOfEvents, eventTypeName, DB_TOTAL_EVENTS_IN_CACHE)
-        PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(numberOfEvents, session.eventType)
-    }
-
-    private suspend fun handleTotalEventsByProducer(session: DbCountingMetricsSession) {
-        session.getProducers().forEach { producerName ->
-            val numberOfEvents = session.getNumberOfEventsFor(producerName)
-            val eventTypeName = session.eventType.toString()
-            val printableAlias = nameScrubber.getPublicAlias(producerName)
-
-            reportEvents(numberOfEvents, eventTypeName, printableAlias, DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER)
-            PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(
-                numberOfEvents,
-                session.eventType,
-                printableAlias
-            )
-        }
-    }
-
-    private suspend fun reportTimeUsed(session: DbCountingMetricsSession, processingTime: Long) {
-        reportProcessingTimeEvent(processingTime, session)
-        PrometheusMetricsCollector.registerProcessingTimeInCache(processingTime, session.eventType)
-    }
-
-    private suspend fun reportEvents(count: Int, eventType: String, producerAlias: String, metricName: String) {
-        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerAlias))
-    }
-
-    private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
-
-    private fun counterField(events: Long): Map<String, Long> = listOf("counter" to events).toMap()
-
-    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
-        listOf("eventType" to eventType, "producer" to producer).toMap()
-
-    private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
-        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))
-    }
-
-    private suspend fun reportProcessingTimeEvent(processingTime: Long, session: DbCountingMetricsSession) {
-        val metricName = DB_COUNT_PROCESSING_TIME
-        metricsReporter.registerDataPoint(
-            metricName, counterField(processingTime),
-            createTagMap(session.eventType.eventType)
-        )
-    }
-
-    private fun createTagMap(eventType: String): Map<String, String> =
-        listOf("eventType" to eventType).toMap()
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsSession.kt
@@ -1,10 +1,14 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSession
 
-class DbCountingMetricsSession(val eventType: EventType) {
+class DbCountingMetricsSession(val eventType: EventType) : CountingMetricsSession {
 
     private val cachedEventsByProducer = HashMap<String, Int>(50)
+
+    private val start = System.nanoTime()
+    private var processingTime : Long = 0L
 
     fun addEventsByProducer(eventsByProducer: Map<String, Int>) {
         eventsByProducer.forEach { producer ->
@@ -28,11 +32,26 @@ class DbCountingMetricsSession(val eventType: EventType) {
         return total
     }
 
+    /**
+     * Databasen inneholder kun unike-eventer, derfor er `getTotalNumber == getNumberOfUniqueEvents`.
+     */
+    override fun getNumberOfUniqueEvents(): Int {
+        return getTotalNumber()
+    }
+
     override fun toString(): String {
         return """DbCountingMetricsSession(
 |                   eventType=$eventType, 
 |                   cachedEventsByProducer=$cachedEventsByProducer
 |                 )""".trimMargin()
+    }
+
+    fun calculateProcessingTime() {
+        processingTime = System.nanoTime() - start
+    }
+
+    fun getProcessingTime(): Long {
+        return processingTime
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbMetricsReporter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbMetricsReporter.kt
@@ -1,0 +1,94 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.MetricsReportingException
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_COUNT_PROCESSING_TIME
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
+import org.slf4j.LoggerFactory
+
+class DbMetricsReporter(
+    private val metricsReporter: MetricsReporter,
+    private val nameScrubber: ProducerNameScrubber
+) {
+
+    private val log = LoggerFactory.getLogger(DbMetricsReporter::class.java)
+
+    suspend fun report(session: DbCountingMetricsSession) {
+        try {
+            reportIfEventsCounted(session)
+
+        } catch (e: Exception) {
+            val msg = "Klarte ikke å rapportere database-metrikker for ${session.eventType.eventType}"
+            throw MetricsReportingException(msg, e)
+        }
+    }
+
+    private suspend fun reportIfEventsCounted(session: DbCountingMetricsSession) {
+        if (session.getProducers().isNotEmpty()) {
+            reportTotalEvents(session)
+            reportTotalEventsByProducer(session)
+            reportTimeUsed(session)
+
+        } else {
+            log.info("Ingen eventer ble funnet for ${session.eventType}.")
+        }
+    }
+
+    private suspend fun reportTotalEvents(session: DbCountingMetricsSession) {
+        val numberOfUniqueEvents = session.getTotalNumber()
+        val eventTypeName = session.eventType.toString()
+
+        reportEvents(numberOfUniqueEvents, eventTypeName, DB_TOTAL_EVENTS_IN_CACHE)
+        PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(numberOfUniqueEvents, session.eventType)
+    }
+
+    private suspend fun reportTotalEventsByProducer(session: DbCountingMetricsSession) {
+        session.getProducers().forEach { producerName ->
+            val numberOfEvents = session.getNumberOfEventsFor(producerName)
+            val eventTypeName = session.eventType.toString()
+            val printableAlias = nameScrubber.getPublicAlias(producerName)
+
+            reportEvents(numberOfEvents, eventTypeName, printableAlias, DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER)
+            PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(
+                numberOfEvents,
+                session.eventType,
+                printableAlias
+            )
+        }
+    }
+
+    private suspend fun reportTimeUsed(session: DbCountingMetricsSession) {
+        reportProcessingTimeEvent(session)
+        PrometheusMetricsCollector.registerProcessingTimeInCache(session.getProcessingTime(), session.eventType)
+    }
+
+    private suspend fun reportEvents(count: Int, eventType: String, producerAlias: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerAlias))
+    }
+
+    private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
+
+    private fun counterField(events: Long): Map<String, Long> = listOf("counter" to events).toMap()
+
+    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
+        listOf("eventType" to eventType, "producer" to producer).toMap()
+
+    private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))
+    }
+
+    private suspend fun reportProcessingTimeEvent(session: DbCountingMetricsSession) {
+        val metricName = DB_COUNT_PROCESSING_TIME
+        metricsReporter.registerDataPoint(
+            metricName, counterField(session.getProcessingTime()),
+            createTagMap(session.eventType.eventType)
+        )
+    }
+
+    private fun createTagMap(eventType: String): Map<String, String> =
+        listOf("eventType" to eventType).toMap()
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbe.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbe.kt
@@ -1,128 +1,17 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.*
 import org.slf4j.LoggerFactory
 
-class TopicMetricsProbe(
-    private val metricsReporter: MetricsReporter,
-    private val nameScrubber: ProducerNameScrubber
-) {
+class TopicMetricsProbe {
 
     private val log = LoggerFactory.getLogger(TopicMetricsProbe::class.java)
 
-    private val lastReportedUniqueEvents = HashMap<EventType, Int>()
-
-    suspend fun runWithMetrics(eventType: EventType, block: suspend TopicMetricsSession.() -> Unit) {
-        val start = System.nanoTime()
+    suspend fun runWithMetrics(eventType: EventType, block: suspend TopicMetricsSession.() -> Unit): TopicMetricsSession {
         val session = TopicMetricsSession(eventType)
         block.invoke(session)
-        val processingTime = System.nanoTime() - start
-
-        if (countedMoreEventsThanLastCount(session, eventType)) {
-            handleUniqueEvents(session)
-            handleTotalNumberOfEvents(session)
-            handleUniqueEventsByProducer(session)
-            handleDuplicatedEventsByProducer(session)
-            handleTotalNumberOfEventsByProducer(session)
-            reportTimeUsed(session, processingTime)
-            lastReportedUniqueEvents[eventType] = session.getNumberOfUniqueEvents()
-
-        } else {
-            val currentCount = session.getNumberOfUniqueEvents()
-            val previousCount = lastReportedUniqueEvents.getOrDefault(eventType, 0)
-            val msg = "Det har oppstått en tellefeil, rapporterer derfor ikke nye metrikker. " +
-                    "Antall unike eventer ved forrige rapportering $previousCount, antall telt nå $currentCount."
-            log.warn(msg)
-        }
+        session.calculateProcessingTime()
+        return session
     }
-
-    private fun countedMoreEventsThanLastCount(session: TopicMetricsSession, eventType: EventType): Boolean {
-        val currentCount = session.getNumberOfUniqueEvents()
-        return currentCount > 0 && currentCount >= lastReportedUniqueEvents.getOrDefault(eventType, 0)
-    }
-
-    private suspend fun handleUniqueEvents(session: TopicMetricsSession) {
-        val uniqueEvents = session.getNumberOfUniqueEvents()
-        val eventTypeName = session.eventType.toString()
-
-        reportEvents(uniqueEvents, eventTypeName, KAFKA_UNIQUE_EVENTS_ON_TOPIC)
-        PrometheusMetricsCollector.registerUniqueEvents(uniqueEvents, session.eventType)
-    }
-
-    private suspend fun handleTotalNumberOfEvents(session: TopicMetricsSession) {
-        val total = session.getTotalNumber()
-        val eventTypeName = session.eventType.toString()
-
-        reportEvents(total, eventTypeName, KAFKA_TOTAL_EVENTS_ON_TOPIC)
-        PrometheusMetricsCollector.registerTotalNumberOfEvents(total, session.eventType)
-    }
-
-    private suspend fun handleUniqueEventsByProducer(session: TopicMetricsSession) {
-        session.getProducersWithUniqueEvents().forEach { producerName ->
-            val uniqueEvents = session.getNumberOfUniqueEvents(producerName)
-            val eventTypeName = session.eventType.toString()
-            val printableAlias = nameScrubber.getPublicAlias(producerName)
-
-            reportEvents(uniqueEvents, eventTypeName, printableAlias, KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER)
-            PrometheusMetricsCollector.registerUniqueEventsByProducer(uniqueEvents, session.eventType, printableAlias)
-        }
-    }
-
-    private suspend fun handleDuplicatedEventsByProducer(session: TopicMetricsSession) {
-        session.getProducersWithDuplicatedEvents().forEach { producerName ->
-            val duplicates = session.getDuplicates(producerName)
-            val eventTypeName = session.eventType.toString()
-            val printableAlias = nameScrubber.getPublicAlias(producerName)
-
-            reportEvents(duplicates, eventTypeName, printableAlias, KAFKA_DUPLICATE_EVENTS_ON_TOPIC)
-            PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(duplicates, session.eventType, printableAlias)
-        }
-    }
-
-    private suspend fun handleTotalNumberOfEventsByProducer(session: TopicMetricsSession) {
-        session.getProducersWithEvents().forEach { producerName ->
-            val total = session.getTotalNumber(producerName)
-            val eventTypeName = session.eventType.toString()
-            val printableAlias = nameScrubber.getPublicAlias(producerName)
-
-            reportEvents(total, eventTypeName, printableAlias, KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER)
-            PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(total, session.eventType, printableAlias)
-        }
-    }
-
-    private suspend fun reportTimeUsed(session: TopicMetricsSession, processingTime: Long) {
-        reportProcessingTimeEvent(processingTime, session)
-        PrometheusMetricsCollector.registerProcessingTime(processingTime, session.eventType)
-    }
-
-    private suspend fun reportEvents(count: Int, eventType: String, producerAlias: String, metricName: String) {
-        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerAlias))
-    }
-
-    private suspend fun reportProcessingTimeEvent(processingTime: Long, session: TopicMetricsSession) {
-        val metricName = KAFKA_COUNT_PROCESSING_TIME
-        metricsReporter.registerDataPoint(
-            metricName, counterField(processingTime),
-            createTagMap(session.eventType.eventType)
-        )
-    }
-
-    private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
-
-    private fun counterField(events: Long): Map<String, Long> = listOf("counter" to events).toMap()
-
-    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
-        listOf("eventType" to eventType, "producer" to producer).toMap()
-
-    private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
-        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))
-    }
-
-    private fun createTagMap(eventType: String): Map<String, String> =
-        listOf("eventType" to eventType).toMap()
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsReporter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsReporter.kt
@@ -1,0 +1,121 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.MetricsReportingException
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.*
+import org.slf4j.LoggerFactory
+
+class TopicMetricsReporter(
+    private val metricsReporter: MetricsReporter,
+    private val nameScrubber: ProducerNameScrubber
+) {
+
+    private val log = LoggerFactory.getLogger(TopicMetricsReporter::class.java)
+
+    suspend fun report(session: TopicMetricsSession) {
+        try {
+            reportIfEventsCounted(session)
+
+        } catch (e: Exception) {
+            val msg = "Klarte ikke å rapportere topic-metrikker for ${session.eventType.eventType}"
+            throw MetricsReportingException(msg, e)
+        }
+    }
+
+    private suspend fun reportIfEventsCounted(session: TopicMetricsSession) {
+        if (session.getNumberOfUniqueEvents() > 0) {
+            reportUniqueEvents(session)
+            reportTotalNumberOfEvents(session)
+            reportUniqueEventsByProducer(session)
+            reportDuplicatedEventsByProducer(session)
+            reportTotalNumberOfEventsByProducer(session)
+            reportTimeUsed(session)
+
+        } else {
+            log.info("Ingen eventer ble funnet for ${session.eventType}.")
+        }
+    }
+
+    private suspend fun reportUniqueEvents(session: TopicMetricsSession) {
+        val uniqueEvents = session.getNumberOfUniqueEvents()
+        val eventTypeName = session.eventType.toString()
+
+        reportEvents(uniqueEvents, eventTypeName, KAFKA_UNIQUE_EVENTS_ON_TOPIC)
+        PrometheusMetricsCollector.registerUniqueEvents(uniqueEvents, session.eventType)
+    }
+
+    private suspend fun reportTotalNumberOfEvents(session: TopicMetricsSession) {
+        val total = session.getTotalNumber()
+        val eventTypeName = session.eventType.toString()
+
+        reportEvents(total, eventTypeName, KAFKA_TOTAL_EVENTS_ON_TOPIC)
+        PrometheusMetricsCollector.registerTotalNumberOfEvents(total, session.eventType)
+    }
+
+    private suspend fun reportUniqueEventsByProducer(session: TopicMetricsSession) {
+        session.getProducersWithUniqueEvents().forEach { producerName ->
+            val uniqueEvents = session.getNumberOfUniqueEvents(producerName)
+            val eventTypeName = session.eventType.toString()
+            val printableAlias = nameScrubber.getPublicAlias(producerName)
+
+            reportEvents(uniqueEvents, eventTypeName, printableAlias, KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER)
+            PrometheusMetricsCollector.registerUniqueEventsByProducer(uniqueEvents, session.eventType, printableAlias)
+        }
+    }
+
+    private suspend fun reportDuplicatedEventsByProducer(session: TopicMetricsSession) {
+        session.getProducersWithDuplicatedEvents().forEach { producerName ->
+            val duplicates = session.getDuplicates(producerName)
+            val eventTypeName = session.eventType.toString()
+            val printableAlias = nameScrubber.getPublicAlias(producerName)
+
+            reportEvents(duplicates, eventTypeName, printableAlias, KAFKA_DUPLICATE_EVENTS_ON_TOPIC)
+            PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(duplicates, session.eventType, printableAlias)
+        }
+    }
+
+    private suspend fun reportTotalNumberOfEventsByProducer(session: TopicMetricsSession) {
+        session.getProducersWithEvents().forEach { producerName ->
+            val total = session.getTotalNumber(producerName)
+            val eventTypeName = session.eventType.toString()
+            val printableAlias = nameScrubber.getPublicAlias(producerName)
+
+            reportEvents(total, eventTypeName, printableAlias, KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER)
+            PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(total, session.eventType, printableAlias)
+        }
+    }
+
+    private suspend fun reportTimeUsed(session: TopicMetricsSession) {
+        reportProcessingTimeEvent(session)
+        PrometheusMetricsCollector.registerProcessingTime(session.getProcessingTime(), session.eventType)
+    }
+
+    private suspend fun reportEvents(count: Int, eventType: String, producerAlias: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType, producerAlias))
+    }
+
+    private suspend fun reportProcessingTimeEvent(session: TopicMetricsSession) {
+        val metricName = KAFKA_COUNT_PROCESSING_TIME
+        metricsReporter.registerDataPoint(
+            metricName, counterField(session.getProcessingTime()),
+            createTagMap(session.eventType.eventType)
+        )
+    }
+
+    private fun counterField(events: Int): Map<String, Int> = listOf("counter" to events).toMap()
+
+    private fun counterField(events: Long): Map<String, Long> = listOf("counter" to events).toMap()
+
+    private fun createTagMap(eventType: String, producer: String): Map<String, String> =
+        listOf("eventType" to eventType, "producer" to producer).toMap()
+
+    private suspend fun reportEvents(count: Int, eventType: String, metricName: String) {
+        metricsReporter.registerDataPoint(metricName, counterField(count), createTagMap(eventType))
+    }
+
+    private fun createTagMap(eventType: String): Map<String, String> =
+        listOf("eventType" to eventType).toMap()
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
@@ -1,9 +1,10 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSession
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 
-class TopicMetricsSession(val eventType: EventType) {
+class TopicMetricsSession(val eventType: EventType) : CountingMetricsSession {
 
     private val treMillioner = 3000000
 
@@ -11,6 +12,9 @@ class TopicMetricsSession(val eventType: EventType) {
     private var totalNumberOfEventsByProducer = HashMap<String, Int>(50)
     private val uniqueEventsOnTopicByProducer = HashMap<String, Int>(50)
     private val uniqueEventsOnTopic = HashSet<UniqueKafkaEventIdentifier>(treMillioner)
+
+    private val start = System.nanoTime()
+    private var processingTime : Long = 0L
 
     fun countEvent(event: UniqueKafkaEventIdentifier) {
         val produsent = event.systembruker
@@ -23,7 +27,7 @@ class TopicMetricsSession(val eventType: EventType) {
         }
     }
 
-    fun getNumberOfUniqueEvents(): Int {
+    override fun getNumberOfUniqueEvents(): Int {
         return uniqueEventsOnTopic.size
     }
 
@@ -74,6 +78,14 @@ class TopicMetricsSession(val eventType: EventType) {
 |                   duplicates=$duplicatesByProdusent, 
 |                   total=$totalNumberOfEventsByProducer, 
 |                 )""".trimMargin()
+    }
+
+    fun calculateProcessingTime() {
+        processingTime = System.nanoTime() - start
+    }
+
+    fun getProcessingTime(): Long {
+        return processingTime
     }
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/metricsProbeSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/metricsProbeSetup.kt
@@ -1,27 +1,10 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics
 
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.database.Database
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.Environment
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsProbe
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.InfluxMetricsReporter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.SensuClient
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsProbe
 
-fun buildTopicMetricsProbe(environment: Environment, database: Database): TopicMetricsProbe {
-    val metricsReporter = resolveMetricsReporter(environment)
-    val nameResolver = ProducerNameResolver(database)
-    val nameScrubber = ProducerNameScrubber(nameResolver)
-    return TopicMetricsProbe(metricsReporter, nameScrubber)
-}
-
-fun buildDbEventCountingMetricsProbe(environment: Environment, database: Database): DbCountingMetricsProbe {
-    val metricsReporter = resolveMetricsReporter(environment)
-    val nameResolver = ProducerNameResolver(database)
-    val nameScrubber = ProducerNameScrubber(nameResolver)
-    return DbCountingMetricsProbe(metricsReporter, nameScrubber)
-}
-
-private fun resolveMetricsReporter(environment: Environment): MetricsReporter {
+fun resolveMetricsReporter(environment: Environment): MetricsReporter {
     return if (environment.sensuHost == "" || environment.sensuHost == "stub") {
         StubMetricsReporter()
     } else {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterService.kt
@@ -29,9 +29,9 @@ class MetricsSubmitterService(
         try {
             val topicSessions = topicEventCounterService.countAllEventTypesAsync()
             val dbSessions = dbEventCounterService.countAllEventTypesAsync()
+            val sessionComparator = SessionComparator(topicSessions, dbSessions)
 
-            // TODO: Legg på sjekk som verifiserer at de samme eventtypene er telt fra både kafka og databasen?
-            topicSessions.getEventTypesWithSession().forEach { eventType ->
+            sessionComparator.eventTypesWithSessionFromBothSources().forEach { eventType ->
                 reportMetricsByEventType(topicSessions, dbSessions, eventType)
             }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterService.kt
@@ -1,0 +1,76 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.CountException
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.MetricsReportingException
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSession
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessions
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsSession
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsSession
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class MetricsSubmitterService(
+    private val dbEventCounterService: DbEventCounterService,
+    private val topicEventCounterService: TopicEventCounterService,
+    private val dbMetricsReporter: DbMetricsReporter,
+    private val kafkaMetricsReporter: TopicMetricsReporter
+) {
+
+    private val log: Logger = LoggerFactory.getLogger(MetricsSubmitterService::class.java)
+
+    private val lastReportedUniqueKafkaEvents = HashMap<EventType, Int>()
+
+    suspend fun submitMetrics() {
+        try {
+            val topicSessions = topicEventCounterService.countAllEventTypesAsync()
+            val dbSessions = dbEventCounterService.countAllEventTypesAsync()
+
+            // TODO: Legg på sjekk som verifiserer at de samme eventtypene er telt fra både kafka og databasen?
+            topicSessions.getEventTypesWithSession().forEach { eventType ->
+                reportMetricsByEventType(topicSessions, dbSessions, eventType)
+            }
+
+        } catch (e: CountException) {
+            log.warn("Klarte ikke å telle eventer", e)
+
+        } catch (e: MetricsReportingException) {
+            log.warn("Klarte ikke å rapportere metrikker", e)
+
+        } catch (e: Exception) {
+            log.error("En uventet feil oppstod, klarte ikke å telle og/eller rapportere metrikker.", e)
+        }
+    }
+
+    private suspend fun reportMetricsByEventType(
+        topicSessions: CountingMetricsSessions,
+        dbSessions: CountingMetricsSessions,
+        eventType: EventType
+    ) {
+        val kafkaEventSession = topicSessions.getForType(eventType)
+
+        if (countedMoreKafkaEventsThanLastCount(kafkaEventSession, eventType)) {
+            val dbSession = dbSessions.getForType(eventType)
+            dbMetricsReporter.report(dbSession as DbCountingMetricsSession)
+            kafkaMetricsReporter.report(kafkaEventSession as TopicMetricsSession)
+            lastReportedUniqueKafkaEvents[eventType] = kafkaEventSession.getNumberOfUniqueEvents()
+
+        } else {
+            val currentCount = kafkaEventSession.getNumberOfUniqueEvents()
+            val previousCount = lastReportedUniqueKafkaEvents.getOrDefault(eventType, 0)
+            val msg = "Det har oppstått en tellefeil, rapporterer derfor ikke nye $eventType-metrikker. " +
+                    "Antall unike eventer ved forrige rapportering $previousCount, antall telt nå $currentCount."
+            log.warn(msg)
+        }
+    }
+
+    private fun countedMoreKafkaEventsThanLastCount(session: CountingMetricsSession, eventType: EventType): Boolean {
+        val currentCount = session.getNumberOfUniqueEvents()
+        return currentCount > 0 && currentCount >= lastReportedUniqueKafkaEvents.getOrDefault(eventType, 0)
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/PeriodicMetricsSubmitter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/PeriodicMetricsSubmitter.kt
@@ -4,8 +4,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.time.delay
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.HealthStatus
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.Status
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -13,9 +11,8 @@ import java.time.Instant
 import kotlin.coroutines.CoroutineContext
 
 class PeriodicMetricsSubmitter(
-        val dbEventCounterService: DbEventCounterService,
-        val topicEventCounterService: TopicEventCounterService,
-        private val job: Job = Job()
+    private val metricsSubmitterService: MetricsSubmitterService,
+    private val job: Job = Job()
 ) : CoroutineScope {
 
     private val log: Logger = LoggerFactory.getLogger(PeriodicMetricsSubmitter::class.java)
@@ -51,11 +48,10 @@ class PeriodicMetricsSubmitter(
     }
 
     suspend fun submitMetrics() {
-        log.info("Starter å rapportere inn metrikker...")
         val start = Instant.now()
+        log.info("Starter å rapportere inn metrikker...")
 
-        topicEventCounterService.countEventsAndReportMetrics()
-        dbEventCounterService.countEventsAndReportMetrics()
+        metricsSubmitterService.submitMetrics()
 
         val elapsedTime = calculateElapsedTime(start)
         log.info("...ferdig med å rapportere inn metrikker, det ${elapsedTime}ms.")
@@ -66,5 +62,4 @@ class PeriodicMetricsSubmitter(
         val elapsedTime = stop.toEpochMilli() - start.toEpochMilli()
         return elapsedTime
     }
-
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/SessionComparator.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/SessionComparator.kt
@@ -1,0 +1,47 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessions
+import org.slf4j.LoggerFactory
+
+class SessionComparator(
+    val topic: CountingMetricsSessions,
+    val database: CountingMetricsSessions
+) {
+
+    private val log = LoggerFactory.getLogger(SessionComparator::class.java)
+
+    private val eventTypesInBothSources = mutableListOf<EventType>()
+
+    init {
+        EventType.values().forEach { eventType ->
+            if (isPresentInBothSources(eventType)) {
+                eventTypesInBothSources.add(eventType)
+
+            } else {
+                logWarningWithInfoAboutWhatSourcesWasMissingTheEventType(eventType)
+            }
+        }
+    }
+
+    private fun isPresentInBothSources(eventType: EventType): Boolean {
+        return topic.getEventTypesWithSession().contains(eventType) && database.getEventTypesWithSession()
+            .contains(eventType)
+    }
+
+    private fun logWarningWithInfoAboutWhatSourcesWasMissingTheEventType(eventType: EventType) {
+        if (topic.getEventTypesWithSession().contains(eventType)) {
+            val numberOfEvents = topic.getForType(eventType).getNumberOfUniqueEvents()
+            log.warn("Eventtypen '$eventType' ble kun telt for topic, og ikke i databasen. Fant $numberOfEvents eventer.")
+
+        } else if (database.getEventTypesWithSession().contains(eventType)) {
+            val numberOfEvents = database.getForType(eventType).getNumberOfUniqueEvents()
+            log.warn("Eventtypen '$eventType' ble kun telt for databasen, og ikke på topic. Fant $numberOfEvents eventer.")
+        }
+    }
+
+    fun eventTypesWithSessionFromBothSources(): List<EventType> {
+        return eventTypesInBothSources
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
@@ -15,11 +15,27 @@ object CountingMetricsSessionsObjectMother {
         }
     }
 
+    fun giveMeDatabaseSessionsForAllEventTypesExceptForInnboks(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.BESKJED, DbCountingMetricsSessionObjectMother.giveMeBeskjedSessionWithOneCountedEvent())
+            put(EventType.DONE, DbCountingMetricsSessionObjectMother.giveMeDoneSessionWithTwoCountedEvents())
+            put(EventType.OPPGAVE, DbCountingMetricsSessionObjectMother.giveMeOppgaveSessionWithFourCountedEvents())
+        }
+    }
+
     fun giveMeTopicSessionsForAllEventTypes(): CountingMetricsSessions {
         return CountingMetricsSessions().apply {
             put(EventType.BESKJED, TopicMetricsSessionObjectMother.giveMeBeskjedSessionWithTwoCountedEvents())
             put(EventType.DONE, TopicMetricsSessionObjectMother.giveMeDoneSessionWithThreeCountedEvent())
             put(EventType.INNBOKS, TopicMetricsSessionObjectMother.giveMeInnboksSessionWithFourCountedEvent())
+            put(EventType.OPPGAVE, TopicMetricsSessionObjectMother.giveMeOppgaveSessionWithFiveCountedEvent())
+        }
+    }
+
+    fun giveMeTopicSessionsForAllEventTypesExceptForInnboks(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.BESKJED, TopicMetricsSessionObjectMother.giveMeBeskjedSessionWithTwoCountedEvents())
+            put(EventType.DONE, TopicMetricsSessionObjectMother.giveMeDoneSessionWithThreeCountedEvent())
             put(EventType.OPPGAVE, TopicMetricsSessionObjectMother.giveMeOppgaveSessionWithFiveCountedEvent())
         }
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
@@ -1,0 +1,36 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsSessionObjectMother
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsSessionObjectMother
+
+object CountingMetricsSessionsObjectMother {
+
+    fun giveMeDatabaseSessionsForAllEventTypes(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.BESKJED, DbCountingMetricsSessionObjectMother.giveMeBeskjedSessionWithOneCountedEvent())
+            put(EventType.DONE, DbCountingMetricsSessionObjectMother.giveMeDoneSessionWithTwoCountedEvents())
+            put(EventType.INNBOKS, DbCountingMetricsSessionObjectMother.giveMeInnboksSessionWithThreeCountedEvents())
+            put(EventType.OPPGAVE, DbCountingMetricsSessionObjectMother.giveMeOppgaveSessionWithFourCountedEvents())
+        }
+    }
+
+    fun giveMeTopicSessionsForAllEventTypes(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.BESKJED, TopicMetricsSessionObjectMother.giveMeBeskjedSessionWithTwoCountedEvents())
+            put(EventType.DONE, TopicMetricsSessionObjectMother.giveMeDoneSessionWithThreeCountedEvent())
+            put(EventType.INNBOKS, TopicMetricsSessionObjectMother.giveMeInnboksSessionWithFourCountedEvent())
+            put(EventType.OPPGAVE, TopicMetricsSessionObjectMother.giveMeOppgaveSessionWithFiveCountedEvent())
+        }
+    }
+
+    fun giveMeTopicSessionsWithSingleEventForAllEventTypes(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.BESKJED, TopicMetricsSessionObjectMother.giveMeBeskjedSessionWithOneCountedEvent())
+            put(EventType.DONE, TopicMetricsSessionObjectMother.giveMeDoneSessionWithOneCountedEvent())
+            put(EventType.INNBOKS, TopicMetricsSessionObjectMother.giveMeInnboksSessionWithOneCountedEvent())
+            put(EventType.OPPGAVE, TopicMetricsSessionObjectMother.giveMeOppgaveSessionWithOneCountedEvent())
+        }
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsProbeTest.kt
@@ -1,119 +1,25 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
 
-import io.mockk.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_COUNT_PROCESSING_TIME
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
-import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.shouldBeGreaterOrEqualTo
-import org.amshove.kluent.shouldBeLessThan
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.amshove.kluent.`should be greater than`
 
 internal class DbCountingMetricsProbeTest {
 
-    private val metricsReporter = mockk<MetricsReporter>(relaxed = true)
-    private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
-    private val producerNameResolver = mockk<ProducerNameResolver>(relaxed = true)
-
-    @BeforeEach
-    fun cleanup() {
-        clearAllMocks()
-    }
-
     @Test
-    fun `Should report correct number of events`() {
-        val dummyCountResultFromDb = mutableMapOf<String, Int>().apply {
-            put("produsent1", 1)
-            put("produsent2", 2)
-        }
-
-        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val topicMetricsProbe = DbCountingMetricsProbe(metricsReporter, nameScrubber)
-
-        val capturedTotalEventsInCacheByProducer = slot<Map<String, Any>>()
-
-        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, capture(capturedTotalEventsInCacheByProducer), any()) } returns Unit
-
-        runBlocking {
-            topicMetricsProbe.runWithMetrics(EventType.BESKJED) {
-                addEventsByProducer(dummyCountResultFromDb)
+    internal fun `Should calculate processing time`() {
+        val probe = DbCountingMetricsProbe()
+        val minimumProcessingTimeInMs: Long = 500
+        val minimumProcessingTimeInNs: Long = minimumProcessingTimeInMs * 1000000
+        val session = runBlocking {
+            probe.runWithMetrics(EventType.BESKJED) {
+                delay(minimumProcessingTimeInMs)
             }
         }
 
-        coVerify(exactly = 4) { metricsReporter.registerDataPoint(any(), any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(3, any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(1, any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(2, any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerProcessingTimeInCache(any(), any()) }
-
-        capturedTotalEventsInCacheByProducer.captured["counter"] `should be equal to` 1
-    }
-
-    @Test
-    fun `Should report the elapsed time to count the events`() {
-        val expectedProcessingTimeMs = 100L
-        val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
-
-        val dummyCountResultFromDb = mutableMapOf<String, Int>().apply {
-            put("produsent1", 1)
-            put("produsent2", 2)
-        }
-
-        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val topicMetricsProbe = DbCountingMetricsProbe(metricsReporter, nameScrubber)
-
-        val capturedProcessingTime = slot<Map<String, Long>>()
-
-        coEvery { metricsReporter.registerDataPoint(DB_COUNT_PROCESSING_TIME, capture(capturedProcessingTime), any()) } returns Unit
-
-        runBlocking {
-            topicMetricsProbe.runWithMetrics(EventType.BESKJED) {
-                addEventsByProducer(dummyCountResultFromDb)
-                delay(expectedProcessingTimeMs)
-            }
-        }
-
-        capturedProcessingTime.captured["counter"]!!.shouldBeGreaterOrEqualTo(expectedProcessingTimeNs)
-        val twentyPercentMoreThanExpectedTime  = (expectedProcessingTimeNs * 1.2).toLong()
-        capturedProcessingTime.captured["counter"]!!.shouldBeLessThan(twentyPercentMoreThanExpectedTime)
-    }
-
-    @Test
-    fun `Should replace system name with alias`() {
-        val producerName = "sys-t-user"
-        val producerAlias = "test-user"
-
-        coEvery { producerNameResolver.getProducerNameAlias(producerName) } returns producerAlias
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val metricsProbe = DbCountingMetricsProbe(metricsReporter, nameScrubber)
-
-        val producerNameForPrometheus = slot<String>()
-        val capturedTagsForTotalByProducer = slot<Map<String, String>>()
-
-        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
-        every { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(any(), any(), capture(producerNameForPrometheus)) } returns Unit
-
-        runBlocking {
-            metricsProbe.runWithMetrics(EventType.BESKJED) {
-                addEventsByProducer(mapOf(Pair(producerName, 2)))
-            }
-        }
-
-        coVerify(exactly = 1) { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, any(), any()) }
-
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(any(), any(), any()) }
-
-        producerNameForPrometheus.captured `should be equal to` producerAlias
-        capturedTagsForTotalByProducer.captured["producer"] `should be equal to` producerAlias
+        session.getProcessingTime() `should be greater than` minimumProcessingTimeInNs
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsSessionObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsSessionObjectMother.kt
@@ -1,0 +1,37 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+
+object DbCountingMetricsSessionObjectMother {
+
+    fun giveMeBeskjedSessionWithOneCountedEvent(): DbCountingMetricsSession {
+        val beskjedSession = DbCountingMetricsSession(EventType.BESKJED)
+        beskjedSession.addEventsByProducer(mapOf("produsent1" to 1))
+        return beskjedSession
+    }
+
+    fun giveMeDoneSessionWithTwoCountedEvents(): DbCountingMetricsSession {
+        val doneSession = DbCountingMetricsSession(EventType.DONE)
+        doneSession.addEventsByProducer(mapOf("produsent2" to 21))
+        doneSession.addEventsByProducer(mapOf("produsent2" to 22))
+        return doneSession
+    }
+
+    fun giveMeInnboksSessionWithThreeCountedEvents(): DbCountingMetricsSession {
+        val innboksSession = DbCountingMetricsSession(EventType.INNBOKS)
+        innboksSession.addEventsByProducer(mapOf("produsent3" to 31))
+        innboksSession.addEventsByProducer(mapOf("produsent3" to 32))
+        innboksSession.addEventsByProducer(mapOf("produsent3" to 33))
+        return innboksSession
+    }
+
+    fun giveMeOppgaveSessionWithFourCountedEvents(): DbCountingMetricsSession {
+        val oppgaveSession = DbCountingMetricsSession(EventType.OPPGAVE)
+        oppgaveSession.addEventsByProducer(mapOf("produsent4" to 41))
+        oppgaveSession.addEventsByProducer(mapOf("produsent4" to 42))
+        oppgaveSession.addEventsByProducer(mapOf("produsent4" to 43))
+        oppgaveSession.addEventsByProducer(mapOf("produsent4" to 44))
+        return oppgaveSession
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsSessionTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbCountingMetricsSessionTest.kt
@@ -28,6 +28,7 @@ internal class DbCountingMetricsSessionTest {
         session.addEventsByProducer(beskjederGruppertPerProdusent)
 
         session.getTotalNumber() `should be equal to` (produsent1Antall + produsent2Antall + produsent3Antall)
+        session.getNumberOfUniqueEvents() `should be equal to` session.getTotalNumber()
 
         session.getProducers().size `should be equal to` alleProdusenter.size
         session.getProducers() shouldContainAll alleProdusenter

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbEventCounterServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbEventCounterServiceTest.kt
@@ -1,0 +1,50 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.`with message containing`
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.CountException
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+
+internal class DbEventCounterServiceTest {
+
+    private val metricsProbe : DbCountingMetricsProbe = mockk(relaxed = true)
+    private val repository : MetricsRepository = mockk(relaxed = true)
+    
+    private val dbEventCounterService = DbEventCounterService(metricsProbe, repository)
+
+    @Test
+    internal fun `Should handle exceptions and rethrow as internal exception`() {
+        val simulatedException = Exception("Simulated error in a test")
+        coEvery { metricsProbe.runWithMetrics(any(), any()) } throws simulatedException
+
+        invoking {
+            runBlocking {
+                dbEventCounterService.countBeskjeder()
+            }
+        } `should throw` CountException::class `with message containing` "beskjed"
+
+        invoking {
+            runBlocking {
+                dbEventCounterService.countDoneEvents()
+            }
+        } `should throw` CountException::class `with message containing` "done"
+
+        invoking {
+            runBlocking {
+                dbEventCounterService.countInnboksEventer()
+            }
+        } `should throw` CountException::class `with message containing` "innboks"
+
+        invoking {
+            runBlocking {
+                dbEventCounterService.countOppgaver()
+            }
+        } `should throw` CountException::class `with message containing` "oppgave"
+
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbMetricsReporterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbMetricsReporterTest.kt
@@ -1,0 +1,150 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
+
+import io.mockk.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.`with message containing`
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.MetricsReportingException
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_COUNT_PROCESSING_TIME
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER
+import org.amshove.kluent.*
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.BeforeEach
+
+internal class DbMetricsReporterTest {
+
+    private val metricsReporter = mockk<MetricsReporter>(relaxed = true)
+    private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
+    private val producerNameResolver = mockk<ProducerNameResolver>(relaxed = true)
+
+    private val nameScrubber = ProducerNameScrubber(producerNameResolver)
+    private val dbMetricsReporter = DbMetricsReporter(metricsReporter, nameScrubber)
+    
+    @BeforeEach
+    fun cleanup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Should report correct number of events`() {
+        val dummyCountResultFromDb = mutableMapOf<String, Int>().apply {
+            put("produsent1", 1)
+            put("produsent2", 2)
+        }
+
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+
+        val capturedTotalEventsInCacheByProducer = slot<Map<String, Any>>()
+
+        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, capture(capturedTotalEventsInCacheByProducer), any()) } returns Unit
+
+        val session = DbCountingMetricsSession(EventType.BESKJED)
+        session.addEventsByProducer(dummyCountResultFromDb)
+        runBlocking {
+            dbMetricsReporter.report(session)
+        }
+
+        coVerify(exactly = 4) { metricsReporter.registerDataPoint(any(), any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCache(3, any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(1, any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(2, any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerProcessingTimeInCache(any(), any()) }
+
+        capturedTotalEventsInCacheByProducer.captured["counter"] `should be equal to` 1
+    }
+
+    @Test
+    fun `Should report the elapsed time to count the events`() {
+        val expectedProcessingTimeMs = 100L
+        val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
+
+        val dummyCountResultFromDb = mutableMapOf<String, Int>().apply {
+            put("produsent1", 1)
+            put("produsent2", 2)
+        }
+
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+
+        val capturedProcessingTime = slot<Map<String, Long>>()
+
+        coEvery { metricsReporter.registerDataPoint(DB_COUNT_PROCESSING_TIME, capture(capturedProcessingTime), any()) } returns Unit
+
+        val session = DbCountingMetricsSession(EventType.BESKJED)
+        session.addEventsByProducer(dummyCountResultFromDb)
+        runBlocking {
+            delay(expectedProcessingTimeMs)
+        }
+        session.calculateProcessingTime()
+        runBlocking {
+            dbMetricsReporter.report(session)
+        }
+
+        capturedProcessingTime.captured["counter"]!!.shouldBeGreaterOrEqualTo(expectedProcessingTimeNs)
+        val twentyPercentMoreThanExpectedTime  = (expectedProcessingTimeNs * 1.2).toLong()
+        capturedProcessingTime.captured["counter"]!!.shouldBeLessThan(twentyPercentMoreThanExpectedTime)
+    }
+
+    @Test
+    fun `Should replace system name with alias`() {
+        val producerName = "sys-t-user"
+        val producerAlias = "test-user"
+
+        coEvery { producerNameResolver.getProducerNameAlias(producerName) } returns producerAlias
+
+        val producerNameForPrometheus = slot<String>()
+        val capturedTagsForTotalByProducer = slot<Map<String, String>>()
+
+        coEvery { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
+        every { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(any(), any(), capture(producerNameForPrometheus)) } returns Unit
+
+        val session = DbCountingMetricsSession(EventType.BESKJED)
+        session.addEventsByProducer(mapOf(Pair(producerName, 2)))
+        runBlocking {
+            dbMetricsReporter.report(session)
+        }
+
+        coVerify(exactly = 1) { metricsReporter.registerDataPoint(DB_TOTAL_EVENTS_IN_CACHE_BY_PRODUCER, any(), any()) }
+
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsInCacheByProducer(any(), any(), any()) }
+
+        producerNameForPrometheus.captured `should be equal to` producerAlias
+        capturedTagsForTotalByProducer.captured["producer"] `should be equal to` producerAlias
+    }
+
+    @Test
+    internal fun `should handle exceptions and rethrow them as internal exceptions`() {
+        val simulatedException = Exception("Simulated error in a test")
+        coEvery { metricsReporter.registerDataPoint(any(), any(), any()) } throws simulatedException
+
+        invoking {
+            runBlocking {
+                dbMetricsReporter.report(DbCountingMetricsSessionObjectMother.giveMeBeskjedSessionWithOneCountedEvent())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "beskjed"
+
+        invoking {
+            runBlocking {
+                dbMetricsReporter.report(DbCountingMetricsSessionObjectMother.giveMeDoneSessionWithTwoCountedEvents())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "done"
+
+        invoking {
+            runBlocking {
+                dbMetricsReporter.report(DbCountingMetricsSessionObjectMother.giveMeInnboksSessionWithThreeCountedEvents())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "innboks"
+
+        invoking {
+            runBlocking {
+                dbMetricsReporter.report(DbCountingMetricsSessionObjectMother.giveMeOppgaveSessionWithFourCountedEvents())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "oppgave"
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceTest.kt
@@ -1,0 +1,61 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.brukernotifikasjon.schemas.Nokkel
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.`with message containing`
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.CountException
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.junit.jupiter.api.Test
+
+internal class TopicEventCounterServiceTest {
+
+    private val beskjedCountConsumer: KafkaConsumer<Nokkel, GenericRecord> = mockk(relaxed = true)
+    private val innboksCountConsumer: KafkaConsumer<Nokkel, GenericRecord> = mockk(relaxed = true)
+    private val oppgaveCountConsumer: KafkaConsumer<Nokkel, GenericRecord> = mockk(relaxed = true)
+    private val doneCountConsumer: KafkaConsumer<Nokkel, GenericRecord> = mockk(relaxed = true)
+    private val topicMetricsProbe: TopicMetricsProbe = mockk(relaxed = true)
+
+    private val topicEventCounterService = TopicEventCounterService(
+        topicMetricsProbe,
+        beskjedCountConsumer,
+        innboksCountConsumer,
+        oppgaveCountConsumer,
+        doneCountConsumer
+    )
+
+    @Test
+    internal fun `Should handle exceptions and rethrow as internal exception`() {
+        val simulatedException = Exception("Simulated error in a test")
+        coEvery { topicMetricsProbe.runWithMetrics(any(), any()) } throws simulatedException
+
+        invoking {
+            runBlocking {
+                topicEventCounterService.countBeskjeder()
+            }
+        } `should throw` CountException::class `with message containing` "beskjed"
+
+        invoking {
+            runBlocking {
+                topicEventCounterService.countDoneEvents()
+            }
+        } `should throw` CountException::class `with message containing` "done"
+
+        invoking {
+            runBlocking {
+                topicEventCounterService.countInnboksEventer()
+            }
+        } `should throw` CountException::class `with message containing` "innboks"
+
+        invoking {
+            runBlocking {
+                topicEventCounterService.countOppgaver()
+            }
+        } `should throw` CountException::class `with message containing` "oppgave"
+
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsProbeTest.kt
@@ -1,189 +1,25 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
-import io.mockk.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.*
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
-import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.shouldBeGreaterOrEqualTo
-import org.amshove.kluent.shouldBeLessThan
-import org.junit.jupiter.api.BeforeEach
+import org.amshove.kluent.`should be greater than`
 import org.junit.jupiter.api.Test
 
 internal class TopicMetricsProbeTest {
 
-    private val metricsReporter = mockk<MetricsReporter>(relaxed = true)
-    private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
-    private val producerNameResolver = mockk<ProducerNameResolver>(relaxed = true)
-
-    @BeforeEach
-    fun cleanup() {
-        clearAllMocks()
-    }
-
     @Test
-    fun `Should report correct number of events`() {
-        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
-
-        val capturedFieldsForUnique = slot<Map<String, Any>>()
-        val capturedFieldsForDuplicated = slot<Map<String, Any>>()
-        val capturedFieldsForTotalEvents = slot<Map<String, Any>>()
-        val capturedFieldsForUniqueByProducer = slot<Map<String, Any>>()
-        val capturedFieldsForTotalEventsByProducer = slot<Map<String, Any>>()
-
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, capture(capturedFieldsForUnique), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, capture(capturedFieldsForTotalEvents), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, capture(capturedFieldsForDuplicated), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, capture(capturedFieldsForTotalEventsByProducer), any()) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, capture(capturedFieldsForUniqueByProducer), any()) } returns Unit
-
-        runBlocking {
-            metricsProbe.runWithMetrics(EventType.BESKJED) {
-                countEvent(UniqueKafkaEventIdentifier("1", "producer", "123"))
-                countEvent(UniqueKafkaEventIdentifier("2", "producer", "123"))
-                countEvent(UniqueKafkaEventIdentifier("3", "producer", "123"))
-                countEvent(UniqueKafkaEventIdentifier("3", "producer", "123"))
+    internal fun `Should calculate processing time`() {
+        val probe = TopicMetricsProbe()
+        val minimumProcessingTimeInMs: Long = 500
+        val minimumProcessingTimeInNs: Long = minimumProcessingTimeInMs * 1000000
+        val session = runBlocking {
+            probe.runWithMetrics(EventType.BESKJED) {
+                delay(minimumProcessingTimeInMs)
             }
         }
 
-        coVerify(exactly = 6) { metricsReporter.registerDataPoint(any(), any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerUniqueEvents(3, any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEvents(4, any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerUniqueEventsByProducer(3, any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(1, any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(4, any(), any()) }
-
-        capturedFieldsForDuplicated.captured["counter"] `should be equal to` 1
-        capturedFieldsForTotalEvents.captured["counter"] `should be equal to` 4
-        capturedFieldsForUnique.captured["counter"] `should be equal to` 3
-        capturedFieldsForUniqueByProducer.captured["counter"] `should be equal to` 3
-        capturedFieldsForTotalEventsByProducer.captured["counter"] `should be equal to` 4
-    }
-
-    @Test
-    fun `Should report the elapsed time to count the events`() {
-        val expectedProcessingTimeMs = 100L
-        val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
-
-        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
-
-        val capturedFieldsForProcessingTime = slot<Map<String, Long>>()
-
-        coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, capture(capturedFieldsForProcessingTime), any()) } returns Unit
-
-        runBlocking {
-            metricsProbe.runWithMetrics(EventType.BESKJED) {
-                countEvent(UniqueKafkaEventIdentifier("1", "sys-t-user", "123"))
-                delay(expectedProcessingTimeMs)
-            }
-        }
-
-        capturedFieldsForProcessingTime.captured["counter"]!!.shouldBeGreaterOrEqualTo(expectedProcessingTimeNs)
-        val fiftyPercentMoreThanExpectedTime  = (expectedProcessingTimeNs * 1.5).toLong()
-        capturedFieldsForProcessingTime.captured["counter"]!!.shouldBeLessThan(fiftyPercentMoreThanExpectedTime)
-    }
-
-    @Test
-    fun `Should replace system name with alias`() {
-        val producerName = "sys-t-user"
-        val producerAlias = "test-user"
-
-        coEvery { producerNameResolver.getProducerNameAlias(producerName) } returns producerAlias
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
-
-        val producerNameForPrometheus = slot<String>()
-        val capturedTagsForUniqueByProducer = slot<Map<String, String>>()
-        val capturedTagsForDuplicates = slot<Map<String, String>>()
-        val capturedTagsForTotalByProducer = slot<Map<String, String>>()
-
-        every { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), capture(producerNameForPrometheus)) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), capture(capturedTagsForDuplicates)) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
-        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForUniqueByProducer)) } returns Unit
-
-        runBlocking {
-            metricsProbe.runWithMetrics(EventType.BESKJED) {
-                countEvent(UniqueKafkaEventIdentifier("1", producerName, "123"))
-                countEvent(UniqueKafkaEventIdentifier("1", producerName, "123"))
-            }
-        }
-
-        coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) }
-        coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), any()) }
-        coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) }
-
-        verify(exactly = 1) { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(any(), any(), any()) }
-        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(any(), any(), any()) }
-
-        producerNameForPrometheus.captured `should be equal to` producerAlias
-        capturedTagsForUniqueByProducer.captured["producer"] `should be equal to` producerAlias
-        capturedTagsForTotalByProducer.captured["producer"] `should be equal to` producerAlias
-        capturedTagsForDuplicates.captured["producer"] `should be equal to` producerAlias
-    }
-
-    @Test
-    fun `Should not report metrics for count sessions with a lower count than the previous count session`() {
-        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
-
-        `sesjon som teller tre eventer`(metricsProbe)
-        `sesjon som feilaktig teller to eventer`(metricsProbe)
-        `sesjon som teller tre eventer`(metricsProbe)
-
-        val numberOfSuccessfulCountingSessions = 2
-        coVerify(exactly = 5 * numberOfSuccessfulCountingSessions) { metricsReporter.registerDataPoint(any(), any(), any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEvents(3, any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEvents(3, any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEventsByProducer(3, any(), any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(3, any(), any()) }
-    }
-
-    @Test
-    fun `Should not report metrics if current count is zero`() {
-        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
-        val nameScrubber = ProducerNameScrubber(producerNameResolver)
-        val metricsProbe = TopicMetricsProbe(metricsReporter, nameScrubber)
-
-        runBlocking {
-            metricsProbe.runWithMetrics(EventType.BESKJED) {
-                // Triggers uten at det blir rapportert noen eventer, for å simulere en feiltelling.
-            }
-        }
-
-        val numberOfSuccessfulCountingSessions = 0
-        coVerify(exactly = numberOfSuccessfulCountingSessions) { metricsReporter.registerDataPoint(any(), any(), any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEvents(any(), any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEvents(any(), any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), any()) }
-        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(any(), any(), any()) }
-    }
-
-    private fun `sesjon som teller tre eventer`(metricsProbe: TopicMetricsProbe) = runBlocking {
-        metricsProbe.runWithMetrics(EventType.BESKJED) {
-            countEvent(UniqueKafkaEventIdentifier("1", "producer", "123"))
-            countEvent(UniqueKafkaEventIdentifier("2", "producer", "123"))
-            countEvent(UniqueKafkaEventIdentifier("3", "producer", "123"))
-        }
-    }
-
-    private fun `sesjon som feilaktig teller to eventer`(metricsProbe: TopicMetricsProbe) = runBlocking {
-        metricsProbe.runWithMetrics(EventType.BESKJED) {
-            countEvent(UniqueKafkaEventIdentifier("1", "producer", "123"))
-            countEvent(UniqueKafkaEventIdentifier("3", "producer", "123"))
-        }
+        session.getProcessingTime() `should be greater than` minimumProcessingTimeInNs
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsReporterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsReporterTest.kt
@@ -1,0 +1,181 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
+
+import io.mockk.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.`with message containing`
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.MetricsReportingException
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.MetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.PrometheusMetricsCollector
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.influx.*
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+import org.amshove.kluent.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TopicMetricsReporterTest {
+
+    private val metricsReporter = mockk<MetricsReporter>(relaxed = true)
+    private val prometheusCollector = mockkObject(PrometheusMetricsCollector)
+    private val producerNameResolver = mockk<ProducerNameResolver>(relaxed = true)
+
+    private val nameScrubber = ProducerNameScrubber(producerNameResolver)
+    private val topicMetricsReporter = TopicMetricsReporter(metricsReporter, nameScrubber)
+
+    @BeforeEach
+    fun cleanup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Should report correct number of events`() {
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+
+        val capturedFieldsForUnique = slot<Map<String, Any>>()
+        val capturedFieldsForDuplicated = slot<Map<String, Any>>()
+        val capturedFieldsForTotalEvents = slot<Map<String, Any>>()
+        val capturedFieldsForUniqueByProducer = slot<Map<String, Any>>()
+        val capturedFieldsForTotalEventsByProducer = slot<Map<String, Any>>()
+
+        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC, capture(capturedFieldsForUnique), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC, capture(capturedFieldsForTotalEvents), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, capture(capturedFieldsForDuplicated), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, capture(capturedFieldsForTotalEventsByProducer), any()) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, capture(capturedFieldsForUniqueByProducer), any()) } returns Unit
+
+        val session = TopicMetricsSession(EventType.BESKJED)
+        session.countEvent(UniqueKafkaEventIdentifier("1", "producer", "123"))
+        session.countEvent(UniqueKafkaEventIdentifier("2", "producer", "123"))
+        session.countEvent(UniqueKafkaEventIdentifier("3", "producer", "123"))
+        session.countEvent(UniqueKafkaEventIdentifier("3", "producer", "123"))
+        runBlocking {
+            topicMetricsReporter.report(session)
+        }
+
+        coVerify(exactly = 6) { metricsReporter.registerDataPoint(any(), any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerUniqueEvents(3, any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEvents(4, any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerUniqueEventsByProducer(3, any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(1, any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(4, any(), any()) }
+
+        capturedFieldsForDuplicated.captured["counter"] `should be equal to` 1
+        capturedFieldsForTotalEvents.captured["counter"] `should be equal to` 4
+        capturedFieldsForUnique.captured["counter"] `should be equal to` 3
+        capturedFieldsForUniqueByProducer.captured["counter"] `should be equal to` 3
+        capturedFieldsForTotalEventsByProducer.captured["counter"] `should be equal to` 4
+    }
+
+    @Test
+    fun `Should report the elapsed time to count the events`() {
+        val expectedProcessingTimeMs = 100L
+        val expectedProcessingTimeNs = expectedProcessingTimeMs * 1000000
+
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+
+        val capturedFieldsForProcessingTime = slot<Map<String, Long>>()
+
+        coEvery { metricsReporter.registerDataPoint(KAFKA_COUNT_PROCESSING_TIME, capture(capturedFieldsForProcessingTime), any()) } returns Unit
+
+        val session = TopicMetricsSession(EventType.BESKJED)
+        session.countEvent(UniqueKafkaEventIdentifier("1", "sys-t-user", "123"))
+        runBlocking { delay(expectedProcessingTimeMs) }
+        session.calculateProcessingTime()
+        runBlocking {
+            topicMetricsReporter.report(session)
+        }
+
+        capturedFieldsForProcessingTime.captured["counter"]!!.shouldBeGreaterOrEqualTo(expectedProcessingTimeNs)
+        val fiftyPercentMoreThanExpectedTime  = (expectedProcessingTimeNs * 1.5).toLong()
+        capturedFieldsForProcessingTime.captured["counter"]!!.shouldBeLessThan(fiftyPercentMoreThanExpectedTime)
+    }
+
+    @Test
+    fun `Should replace system name with alias`() {
+        val producerName = "sys-t-user"
+        val producerAlias = "test-user"
+
+        coEvery { producerNameResolver.getProducerNameAlias(producerName) } returns producerAlias
+
+        val producerNameForPrometheus = slot<String>()
+        val capturedTagsForUniqueByProducer = slot<Map<String, String>>()
+        val capturedTagsForDuplicates = slot<Map<String, String>>()
+        val capturedTagsForTotalByProducer = slot<Map<String, String>>()
+
+        every { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), capture(producerNameForPrometheus)) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), capture(capturedTagsForDuplicates)) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForTotalByProducer)) } returns Unit
+        coEvery { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), capture(capturedTagsForUniqueByProducer)) } returns Unit
+
+        val session = TopicMetricsSession(EventType.BESKJED)
+        session.countEvent(UniqueKafkaEventIdentifier("1", producerName, "123"))
+        session.countEvent(UniqueKafkaEventIdentifier("1", producerName, "123"))
+        runBlocking {
+            topicMetricsReporter.report(session)
+        }
+
+        coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_UNIQUE_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) }
+        coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_DUPLICATE_EVENTS_ON_TOPIC, any(), any()) }
+        coVerify(exactly = 1) { metricsReporter.registerDataPoint(KAFKA_TOTAL_EVENTS_ON_TOPIC_BY_PRODUCER, any(), any()) }
+
+        verify(exactly = 1) { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerDuplicatedEventsOnTopic(any(), any(), any()) }
+        verify(exactly = 1) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(any(), any(), any()) }
+
+        producerNameForPrometheus.captured `should be equal to` producerAlias
+        capturedTagsForUniqueByProducer.captured["producer"] `should be equal to` producerAlias
+        capturedTagsForTotalByProducer.captured["producer"] `should be equal to` producerAlias
+        capturedTagsForDuplicates.captured["producer"] `should be equal to` producerAlias
+    }
+
+    @Test
+    fun `Should not report metrics if current count is zero`() {
+        coEvery { producerNameResolver.getProducerNameAlias(any()) } returns "test-user"
+
+        val sessionWithoutAnyReportedEventsSimulatesACountError = TopicMetricsSession(EventType.BESKJED)
+        runBlocking {
+            topicMetricsReporter.report(sessionWithoutAnyReportedEventsSimulatesACountError)
+        }
+
+        val numberOfSuccessfulCountingSessions = 0
+        coVerify(exactly = numberOfSuccessfulCountingSessions) { metricsReporter.registerDataPoint(any(), any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEvents(any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEvents(any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerUniqueEventsByProducer(any(), any(), any()) }
+        verify(exactly = numberOfSuccessfulCountingSessions) { PrometheusMetricsCollector.registerTotalNumberOfEventsByProducer(any(), any(), any()) }
+    }
+
+    @Test
+    internal fun `should handle exceptions and rethrow them as internal exceptions`() {
+        val simulatedException = Exception("Simulated error in a test")
+        coEvery { metricsReporter.registerDataPoint(any(), any(), any()) } throws simulatedException
+
+        invoking {
+            runBlocking {
+                topicMetricsReporter.report(TopicMetricsSessionObjectMother.giveMeBeskjedSessionWithOneCountedEvent())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "beskjed"
+
+        invoking {
+            runBlocking {
+                topicMetricsReporter.report(TopicMetricsSessionObjectMother.giveMeDoneSessionWithOneCountedEvent())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "done"
+
+        invoking {
+            runBlocking {
+                topicMetricsReporter.report(TopicMetricsSessionObjectMother.giveMeInnboksSessionWithOneCountedEvent())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "innboks"
+
+        invoking {
+            runBlocking {
+                topicMetricsReporter.report(TopicMetricsSessionObjectMother.giveMeOppgaveSessionWithOneCountedEvent())
+            }
+        } `should throw` MetricsReportingException::class `with message containing` "oppgave"
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSessionObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSessionObjectMother.kt
@@ -1,0 +1,66 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+
+object TopicMetricsSessionObjectMother {
+
+    fun giveMeBeskjedSessionWithOneCountedEvent(): TopicMetricsSession {
+        val beskjedSession = TopicMetricsSession(EventType.BESKJED)
+        beskjedSession.countEvent(UniqueKafkaEventIdentifier("1", "sysBruker", "123"))
+        return beskjedSession
+    }
+
+    fun giveMeBeskjedSessionWithTwoCountedEvents(): TopicMetricsSession {
+        val beskjedSession = TopicMetricsSession(EventType.BESKJED)
+        beskjedSession.countEvent(UniqueKafkaEventIdentifier("21", "sysBruker", "123"))
+        beskjedSession.countEvent(UniqueKafkaEventIdentifier("22", "sysBruker", "123"))
+        return beskjedSession
+    }
+
+    fun giveMeDoneSessionWithOneCountedEvent(): TopicMetricsSession {
+        val doneSession = TopicMetricsSession(EventType.DONE)
+        doneSession.countEvent(UniqueKafkaEventIdentifier("21", "sysBruker", "123"))
+        return doneSession
+    }
+
+    fun giveMeDoneSessionWithThreeCountedEvent(): TopicMetricsSession {
+        val doneSession = TopicMetricsSession(EventType.DONE)
+        doneSession.countEvent(UniqueKafkaEventIdentifier("31", "sysBruker", "123"))
+        doneSession.countEvent(UniqueKafkaEventIdentifier("32", "sysBruker", "123"))
+        doneSession.countEvent(UniqueKafkaEventIdentifier("33", "sysBruker", "123"))
+        return doneSession
+    }
+
+    fun giveMeInnboksSessionWithOneCountedEvent(): TopicMetricsSession {
+        val innboksSession = TopicMetricsSession(EventType.INNBOKS)
+        innboksSession.countEvent(UniqueKafkaEventIdentifier("31", "sysBruker", "123"))
+        return innboksSession
+    }
+
+    fun giveMeInnboksSessionWithFourCountedEvent(): TopicMetricsSession {
+        val innboksSession = TopicMetricsSession(EventType.INNBOKS)
+        innboksSession.countEvent(UniqueKafkaEventIdentifier("41", "sysBruker", "123"))
+        innboksSession.countEvent(UniqueKafkaEventIdentifier("42", "sysBruker", "123"))
+        innboksSession.countEvent(UniqueKafkaEventIdentifier("43", "sysBruker", "123"))
+        innboksSession.countEvent(UniqueKafkaEventIdentifier("44", "sysBruker", "123"))
+        return innboksSession
+    }
+
+    fun giveMeOppgaveSessionWithOneCountedEvent(): TopicMetricsSession {
+        val oppgaveSession = TopicMetricsSession(EventType.OPPGAVE)
+        oppgaveSession.countEvent(UniqueKafkaEventIdentifier("41", "sysBruker", "123"))
+        return oppgaveSession
+    }
+
+    fun giveMeOppgaveSessionWithFiveCountedEvent(): TopicMetricsSession {
+        val oppgaveSession = TopicMetricsSession(EventType.OPPGAVE)
+        oppgaveSession.countEvent(UniqueKafkaEventIdentifier("51", "sysBruker", "123"))
+        oppgaveSession.countEvent(UniqueKafkaEventIdentifier("52", "sysBruker", "123"))
+        oppgaveSession.countEvent(UniqueKafkaEventIdentifier("53", "sysBruker", "123"))
+        oppgaveSession.countEvent(UniqueKafkaEventIdentifier("54", "sysBruker", "123"))
+        oppgaveSession.countEvent(UniqueKafkaEventIdentifier("55", "sysBruker", "123"))
+        return oppgaveSession
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterServiceTest.kt
@@ -1,0 +1,114 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessionsObjectMother
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsReporter
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class MetricsSubmitterServiceTest {
+
+    private val dbMetricsReporter: DbMetricsReporter = mockk(relaxed = true)
+    private val kafkaMetricsReporter: TopicMetricsReporter = mockk(relaxed = true)
+    private val dbEventCounterService: DbEventCounterService = mockk(relaxed = true)
+    private val topicEventCounterService: TopicEventCounterService = mockk(relaxed = true)
+
+    private val submitter = MetricsSubmitterService(
+        dbEventCounterService,
+        topicEventCounterService,
+        dbMetricsReporter,
+        kafkaMetricsReporter
+    )
+
+    @BeforeEach
+    fun cleanup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Should report metrics for both kafka topics and the database cache`() {
+        val topicMetricsSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypes()
+        val dbMetricsSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypes()
+        coEvery { topicEventCounterService.countAllEventTypesAsync() } returns topicMetricsSessions
+        coEvery { dbEventCounterService.countAllEventTypesAsync() } returns dbMetricsSessions
+
+        runBlocking {
+            submitter.submitMetrics()
+        }
+
+        coVerify(exactly = 1) { topicEventCounterService.countAllEventTypesAsync() }
+        coVerify(exactly = 1) { dbEventCounterService.countAllEventTypesAsync() }
+
+        coVerify(exactly = 4) { kafkaMetricsReporter.report(any()) }
+        coVerify(exactly = 4) { dbMetricsReporter.report(any()) }
+
+        confirmVerified(topicEventCounterService)
+        confirmVerified(dbEventCounterService)
+        confirmVerified(kafkaMetricsReporter)
+        confirmVerified(dbMetricsReporter)
+    }
+
+    // Sjekk at det ikke rapporteres hvis det ikke her telt for Innboks.
+
+
+    @Test
+    fun `Should not report metrics for count sessions with a lower count than the previous count session`() {
+        val sessionWithCorretCount = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypes()
+        val simulatedWrongCount =
+            CountingMetricsSessionsObjectMother.giveMeTopicSessionsWithSingleEventForAllEventTypes()
+        val dbMetricsSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypes()
+        coEvery {
+            topicEventCounterService.countAllEventTypesAsync()
+        } returns sessionWithCorretCount andThen simulatedWrongCount andThen sessionWithCorretCount
+
+        coEvery {
+            dbEventCounterService.countAllEventTypesAsync()
+        } returns dbMetricsSessions
+
+        runBlocking {
+            submitter.submitMetrics()
+            submitter.submitMetrics()
+            submitter.submitMetrics()
+        }
+
+        coVerify(exactly = 3) { topicEventCounterService.countAllEventTypesAsync() }
+        coVerify(exactly = 3) { dbEventCounterService.countAllEventTypesAsync() }
+
+        coVerify(exactly = 4 * 2) { kafkaMetricsReporter.report(any()) }
+        coVerify(exactly = 4 * 2) { dbMetricsReporter.report(any()) }
+
+        confirmVerified(topicEventCounterService)
+        confirmVerified(dbEventCounterService)
+        confirmVerified(kafkaMetricsReporter)
+        confirmVerified(dbMetricsReporter)
+    }
+
+    @Test
+    fun `Should not report metrics if one of the counting fails`() {
+        val simulatedException = Exception("Simulated error in a test")
+        val topicMetricsSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypes()
+        val dbMetricsSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypes()
+        coEvery { topicEventCounterService.countAllEventTypesAsync() } returns topicMetricsSessions
+        coEvery { dbEventCounterService.countAllEventTypesAsync() } throws simulatedException andThen dbMetricsSessions
+
+        runBlocking {
+            submitter.submitMetrics()
+        }
+
+        coVerify(exactly = 1) { topicEventCounterService.countAllEventTypesAsync() }
+        coVerify(exactly = 1) { dbEventCounterService.countAllEventTypesAsync() }
+
+        coVerify(exactly = 0) { kafkaMetricsReporter.report(any()) }
+        coVerify(exactly = 0) { dbMetricsReporter.report(any()) }
+
+        confirmVerified(topicEventCounterService)
+        confirmVerified(dbEventCounterService)
+        confirmVerified(kafkaMetricsReporter)
+        confirmVerified(dbMetricsReporter)
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterServiceTest.kt
@@ -2,11 +2,16 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter
 
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessionsObjectMother
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsSession
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbMetricsReporter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsSession
+import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should not contain`
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -52,8 +57,45 @@ internal class MetricsSubmitterServiceTest {
         confirmVerified(dbMetricsReporter)
     }
 
-    // Sjekk at det ikke rapporteres hvis det ikke her telt for Innboks.
+    @Test
+    fun `Should not report metrics for event types without metrics session`() {
+        val topicMetricsSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypesExceptForInnboks()
+        val dbMetricsSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypesExceptForInnboks()
+        coEvery { topicEventCounterService.countAllEventTypesAsync() } returns topicMetricsSessions
+        coEvery { dbEventCounterService.countAllEventTypesAsync() } returns dbMetricsSessions
 
+        val reportedTopicMetricsForEventTypes = mutableListOf<EventType>()
+        val capturedReportedTopicMetrics = slot<TopicMetricsSession>()
+        coEvery {
+            kafkaMetricsReporter.report(capture(capturedReportedTopicMetrics))
+        } answers {
+            val currentlyCapturedEventType = capturedReportedTopicMetrics.captured.eventType
+            reportedTopicMetricsForEventTypes.add(currentlyCapturedEventType)
+        }
+
+        val reportedDbMetricsForEventTypes = mutableListOf<EventType>()
+        val capturedReportedDbMetrics = slot<DbCountingMetricsSession>()
+        coEvery {
+            dbMetricsReporter.report(capture(capturedReportedDbMetrics))
+        } answers {
+            val currentlyCapturedEventType = capturedReportedDbMetrics.captured.eventType
+            reportedDbMetricsForEventTypes.add(currentlyCapturedEventType)
+        }
+
+        runBlocking {
+            submitter.submitMetrics()
+        }
+
+        reportedTopicMetricsForEventTypes `should not contain` EventType.INNBOKS
+        reportedTopicMetricsForEventTypes `should contain` EventType.BESKJED
+        reportedTopicMetricsForEventTypes `should contain` EventType.DONE
+        reportedTopicMetricsForEventTypes `should contain` EventType.OPPGAVE
+
+        reportedDbMetricsForEventTypes `should not contain` EventType.INNBOKS
+        reportedDbMetricsForEventTypes `should contain` EventType.BESKJED
+        reportedDbMetricsForEventTypes `should contain` EventType.DONE
+        reportedDbMetricsForEventTypes `should contain` EventType.OPPGAVE
+    }
 
     @Test
     fun `Should not report metrics for count sessions with a lower count than the previous count session`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/PeriodicMetricsSubmitterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/PeriodicMetricsSubmitterTest.kt
@@ -4,29 +4,23 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter.PeriodicMetricsSubmitter
 import org.junit.jupiter.api.Test
 
 internal class PeriodicMetricsSubmitterTest {
 
     @Test
     fun `Should report metrics for both kafka topics and the database cache`() {
-        val topicEventCounterService = mockk<TopicEventCounterService>(relaxed = true)
-        val dbEventCounterService = mockk<DbEventCounterService>(relaxed = true)
+        val metricsSubmitterService = mockk<MetricsSubmitterService>(relaxed = true)
 
-        val submitter = PeriodicMetricsSubmitter(dbEventCounterService, topicEventCounterService)
+        val submitter = PeriodicMetricsSubmitter(metricsSubmitterService)
 
         runBlocking {
             submitter.submitMetrics()
         }
 
-        coVerify(exactly = 1) { topicEventCounterService.countEventsAndReportMetrics() }
-        coVerify(exactly = 1) { dbEventCounterService.countEventsAndReportMetrics() }
+        coVerify(exactly = 1) { metricsSubmitterService.submitMetrics() }
 
-        confirmVerified(topicEventCounterService)
-        confirmVerified(dbEventCounterService)
+        confirmVerified(metricsSubmitterService)
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/SessionComparatorTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/SessionComparatorTest.kt
@@ -1,0 +1,40 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessionsObjectMother
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class SessionComparatorTest {
+
+    @Test
+    fun `Should return all sessions from both sources, when the have the same session types`() {
+        val allTopicSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypesExceptForInnboks()
+        val allDbSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypesExceptForInnboks()
+
+        val comparator = SessionComparator(allTopicSessions, allDbSessions)
+
+        comparator.eventTypesWithSessionFromBothSources().size `should be equal to` allTopicSessions.getEventTypesWithSession().size
+        comparator.eventTypesWithSessionFromBothSources().size `should be equal to` allDbSessions.getEventTypesWithSession().size
+    }
+
+    @Test
+    fun `Should only return sessions present in both sources, if one topic session is missing`() {
+        val oneTopicSessionMissing = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypesExceptForInnboks()
+        val allDbSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypes()
+
+        val comparator = SessionComparator(oneTopicSessionMissing, allDbSessions)
+
+        comparator.eventTypesWithSessionFromBothSources().size `should be equal to` oneTopicSessionMissing.getEventTypesWithSession().size
+    }
+
+    @Test
+    fun `Should only return sessions present in both sources, if one database session is missing`() {
+        val oneDbSessionMissing = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllEventTypesExceptForInnboks()
+        val allTopicSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllEventTypes()
+
+        val comparator = SessionComparator(allTopicSessions, oneDbSessionMissing)
+
+        comparator.eventTypesWithSessionFromBothSources().size `should be equal to` oneDbSessionMissing.getEventTypesWithSession().size
+    }
+
+}


### PR DESCRIPTION
Hovedendringen her er at metrikkene blir telt opp først, både fra topic og databasen, og deretter rapportert. Tidligere ble alle metrikker rapportert rett etter at de var telt, dermed visste vi ikke om tellingen hadde gått bra for begge kilder før metrikkene ble rapportert.

Nå telles det først fra topic-ene i parallell, og resultatet blir tatt vare på. Deretter telles det fra databasen, og resultatet blir tatt vare på. Til slutt sammenlignes det og sjekkes at man har fått telt for de samme eventtypene for både topic og databasen, og man rapporterer metrikker for begge. Hvis det for en eventtype ikke blir telt fra begge kilder, så vil det ikke blir rapportert noen metriker for den eventtypen. Dette blir også logget.

Dette vil gjøre det lettere å innføre delta-telling, fordi man da har mulighet til å se på telleresultatene og se om det kan være en feiltelling.

PB-524. Effektivisere tellingen av eventer på topic