### PR TITLE
Memory optimization simple

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
@@ -8,12 +8,11 @@ class TopicMetricsSession : CountingMetricsSession {
 
     val eventType: EventType
 
-    private val treMillioner = 3000000
 
     private var duplicatesByProdusent: MutableMap<String, Int>
     private var totalNumberOfEventsByProducer: MutableMap<String, Int>
     private val uniqueEventsOnTopicByProducer: MutableMap<String, Int>
-    private val uniqueEventsOnTopic: MutableSet<UniqueKafkaEventIdentifier>
+    private val uniqueEventsOnTopic: UniqueEventsTracker
 
     private val start = System.nanoTime()
     private var processingTime : Long = 0L
@@ -23,7 +22,7 @@ class TopicMetricsSession : CountingMetricsSession {
         this.duplicatesByProdusent = HashMap(50)
         this.totalNumberOfEventsByProducer = HashMap(50)
         this.uniqueEventsOnTopicByProducer = HashMap(50)
-        this.uniqueEventsOnTopic = HashSet(treMillioner)
+        this.uniqueEventsOnTopic = UniqueEventsTracker(expectedEventsPerUserPerProducer = 3)
     }
 
     constructor(previousSession: TopicMetricsSession) {
@@ -37,7 +36,7 @@ class TopicMetricsSession : CountingMetricsSession {
     fun countEvent(event: UniqueKafkaEventIdentifier) {
         val produsent = event.systembruker
         totalNumberOfEventsByProducer[produsent] = totalNumberOfEventsByProducer.getOrDefault(produsent, 0).inc()
-        val wasNewUniqueEvent = uniqueEventsOnTopic.add(event)
+        val wasNewUniqueEvent = uniqueEventsOnTopic.addEvent(event)
         if (wasNewUniqueEvent) {
             uniqueEventsOnTopicByProducer[produsent] = uniqueEventsOnTopicByProducer.getOrDefault(produsent, 0).inc()
         } else {
@@ -46,7 +45,7 @@ class TopicMetricsSession : CountingMetricsSession {
     }
 
     override fun getNumberOfUniqueEvents(): Int {
-        return uniqueEventsOnTopic.size
+        return uniqueEventsOnTopic.uniqueEvents
     }
 
     fun getNumberOfUniqueEvents(produsent: String): Int {
@@ -105,5 +104,4 @@ class TopicMetricsSession : CountingMetricsSession {
     fun getProcessingTime(): Long {
         return processingTime
     }
-
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
@@ -23,7 +23,7 @@ class TopicMetricsSession : CountingMetricsSession {
         this.duplicatesByProdusent = HashMap(50)
         this.totalNumberOfEventsByProducer = HashMap(50)
         this.uniqueEventsOnTopicByProducer = HashMap(50)
-        this.uniqueEventsOnTopic = UniqueEventsTracker(expectedEventsPerUserPerProducer = 3)
+        this.uniqueEventsOnTopic = UniqueEventsTracker()
     }
 
     constructor(previousSession: TopicMetricsSession) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSession.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSession
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.UniqueEventsTracker
 
 class TopicMetricsSession : CountingMetricsSession {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/UniqueEventsTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/UniqueEventsTracker.kt
@@ -1,0 +1,46 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+
+class UniqueEventsTracker(private val expectedEventsPerUserPerProducer: Int) {
+
+    private val perProducerMap = HashMap<String, PerProducerTracker>()
+
+    private var uniqueEventsVar: Int = 0
+
+    val uniqueEvents: Int get() = uniqueEventsVar
+
+    fun addEvent(eventIdentifier: UniqueKafkaEventIdentifier): Boolean {
+        return if (perProducerMap.containsKey(eventIdentifier.systembruker)) {
+            val isUnique = perProducerMap[eventIdentifier.systembruker]!!.addEvent(eventIdentifier)
+
+            if (isUnique) {
+                uniqueEventsVar++
+            }
+
+            isUnique
+        } else {
+            perProducerMap[eventIdentifier.systembruker] = PerProducerTracker(eventIdentifier, expectedEventsPerUserPerProducer)
+            uniqueEventsVar++
+            true
+        }
+    }
+}
+
+private class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier, expectedEventsPerUserPerProducer: Int) {
+
+    private val userEventIds = HashSet<UserEventIdEntry>(expectedEventsPerUserPerProducer)
+
+    fun addEvent(uniqueKafkaEventIdentifier: UniqueKafkaEventIdentifier): Boolean {
+        return userEventIds.add(UserEventIdEntry(uniqueKafkaEventIdentifier.fodselsnummer, uniqueKafkaEventIdentifier.eventId))
+    }
+
+    init {
+        userEventIds.add(UserEventIdEntry(initialEntry.fodselsnummer, initialEntry.eventId))
+    }
+}
+
+private data class UserEventIdEntry(
+        val fodselsnummer: String,
+        val eventId: String
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
@@ -1,0 +1,21 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
+
+interface Fodselsnummer {
+    companion object {
+
+        fun fromString(fodselsnummerString: String): Fodselsnummer {
+            val longValue = fodselsnummerString.toLongOrNull()
+
+            return if (longValue != null) {
+                FodselsnummerNumeric(longValue)
+            } else {
+                FodselsnummerString(fodselsnummerString)
+            }
+        }
+
+    }
+}
+
+data class FodselsnummerString(val stringValue: String): Fodselsnummer
+
+data class FodselsnummerNumeric(val longValue: Long): Fodselsnummer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -1,0 +1,48 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+
+class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier, expectedEventsPerUserPerProducer: Int) {
+
+    private val userEventIds = HashSet<UserEventIdEntry>(expectedEventsPerUserPerProducer)
+
+    fun addEvent(uniqueKafkaEventIdentifier: UniqueKafkaEventIdentifier): Boolean {
+        return userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(uniqueKafkaEventIdentifier))
+    }
+
+    init {
+        userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(initialEntry))
+    }
+}
+
+private data class UserEventIdEntry(
+        val fodselsnummer: Fodselsnummer,
+        val eventId: String
+) {
+    companion object {
+        fun fromUniqueIdentifier(uniqueIdentifier: UniqueKafkaEventIdentifier) =
+                UserEventIdEntry(Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer), uniqueIdentifier.eventId)
+    }
+}
+
+private data class Fodselsnummer (
+        val longValue: Long?,
+        val stringValue: String?
+) {
+
+    companion object {
+
+        fun fromString(fodselsnummerString: String): Fodselsnummer {
+            val longValue = fodselsnummerString.toLongOrNull()
+
+            val stringValue = if (longValue == null) {
+                fodselsnummerString
+            } else {
+                null
+            }
+
+            return Fodselsnummer(longValue, stringValue)
+        }
+
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -2,27 +2,26 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 
-class PerProducerTracker(
-        initialEntry: UniqueKafkaEventIdentifier,
-        private val expectedEventsPerUserPerProducer: Int
-) {
+class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier, expectedEventsPerUserPerProducer: Int) {
 
-    private val eventIdsPerUser = HashMap<Fodselsnummer, HashSet<String>>()
+    private val userEventIds = HashSet<UserEventIdEntry>(expectedEventsPerUserPerProducer)
 
     fun addEvent(uniqueKafkaEventIdentifier: UniqueKafkaEventIdentifier): Boolean {
-        val fodselsnummer = Fodselsnummer.fromString(uniqueKafkaEventIdentifier.fodselsnummer)
-
-        return if (eventIdsPerUser.containsKey(fodselsnummer)) {
-            eventIdsPerUser[fodselsnummer]!!.add(uniqueKafkaEventIdentifier.eventId)
-        } else {
-            eventIdsPerUser[fodselsnummer] = HashSet(expectedEventsPerUserPerProducer)
-            eventIdsPerUser[fodselsnummer]!!.add(uniqueKafkaEventIdentifier.eventId)
-            true
-        }
+        return userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(uniqueKafkaEventIdentifier))
     }
 
     init {
-        addEvent(initialEntry)
+        userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(initialEntry))
+    }
+}
+
+private data class UserEventIdEntry(
+        val fodselsnummer: Fodselsnummer,
+        val eventId: String
+) {
+    companion object {
+        fun fromUniqueIdentifier(uniqueIdentifier: UniqueKafkaEventIdentifier) =
+                UserEventIdEntry(Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer), uniqueIdentifier.eventId)
     }
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -2,26 +2,27 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 
-class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier, expectedEventsPerUserPerProducer: Int) {
+class PerProducerTracker(
+        initialEntry: UniqueKafkaEventIdentifier,
+        private val expectedEventsPerUserPerProducer: Int
+) {
 
-    private val userEventIds = HashSet<UserEventIdEntry>(expectedEventsPerUserPerProducer)
+    private val eventIdsPerUser = HashMap<Fodselsnummer, HashSet<String>>()
 
     fun addEvent(uniqueKafkaEventIdentifier: UniqueKafkaEventIdentifier): Boolean {
-        return userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(uniqueKafkaEventIdentifier))
+        val fodselsnummer = Fodselsnummer.fromString(uniqueKafkaEventIdentifier.fodselsnummer)
+
+        return if (eventIdsPerUser.containsKey(fodselsnummer)) {
+            eventIdsPerUser[fodselsnummer]!!.add(uniqueKafkaEventIdentifier.eventId)
+        } else {
+            eventIdsPerUser[fodselsnummer] = HashSet(expectedEventsPerUserPerProducer)
+            eventIdsPerUser[fodselsnummer]!!.add(uniqueKafkaEventIdentifier.eventId)
+            true
+        }
     }
 
     init {
-        userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(initialEntry))
-    }
-}
-
-private data class UserEventIdEntry(
-        val fodselsnummer: Fodselsnummer,
-        val eventId: String
-) {
-    companion object {
-        fun fromUniqueIdentifier(uniqueIdentifier: UniqueKafkaEventIdentifier) =
-                UserEventIdEntry(Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer), uniqueIdentifier.eventId)
+        addEvent(initialEntry)
     }
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -25,24 +25,22 @@ private data class UserEventIdEntry(
     }
 }
 
-private data class Fodselsnummer (
-        val longValue: Long?,
-        val stringValue: String?
-) {
-
+private interface Fodselsnummer {
     companion object {
 
         fun fromString(fodselsnummerString: String): Fodselsnummer {
             val longValue = fodselsnummerString.toLongOrNull()
 
-            val stringValue = if (longValue == null) {
-                fodselsnummerString
+            return if (longValue != null) {
+                FodselsnummerNumeric(longValue)
             } else {
-                null
+                FodselsnummerString(fodselsnummerString)
             }
-
-            return Fodselsnummer(longValue, stringValue)
         }
 
     }
 }
+
+private data class FodselsnummerString(val stringValue: String): Fodselsnummer
+
+private data class FodselsnummerNumeric(val longValue: Long): Fodselsnummer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -21,26 +21,9 @@ private data class UserEventIdEntry(
 ) {
     companion object {
         fun fromUniqueIdentifier(uniqueIdentifier: UniqueKafkaEventIdentifier) =
-                UserEventIdEntry(Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer), uniqueIdentifier.eventId)
+                UserEventIdEntry(
+                        fodselsnummer = Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer),
+                        eventId =  uniqueIdentifier.eventId
+                )
     }
 }
-
-private interface Fodselsnummer {
-    companion object {
-
-        fun fromString(fodselsnummerString: String): Fodselsnummer {
-            val longValue = fodselsnummerString.toLongOrNull()
-
-            return if (longValue != null) {
-                FodselsnummerNumeric(longValue)
-            } else {
-                FodselsnummerString(fodselsnummerString)
-            }
-        }
-
-    }
-}
-
-private data class FodselsnummerString(val stringValue: String): Fodselsnummer
-
-private data class FodselsnummerNumeric(val longValue: Long): Fodselsnummer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -2,9 +2,9 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 
-class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier, expectedEventsPerUserPerProducer: Int) {
+class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier) {
 
-    private val userEventIds = HashSet<UserEventIdEntry>(expectedEventsPerUserPerProducer)
+    private val userEventIds = HashSet<UserEventIdEntry>()
 
     fun addEvent(uniqueKafkaEventIdentifier: UniqueKafkaEventIdentifier): Boolean {
         return userEventIds.add(UserEventIdEntry.fromUniqueIdentifier(uniqueKafkaEventIdentifier))

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/UniqueEventsTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/UniqueEventsTracker.kt
@@ -1,4 +1,4 @@
-package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 
@@ -26,21 +26,3 @@ class UniqueEventsTracker(private val expectedEventsPerUserPerProducer: Int) {
         }
     }
 }
-
-private class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier, expectedEventsPerUserPerProducer: Int) {
-
-    private val userEventIds = HashSet<UserEventIdEntry>(expectedEventsPerUserPerProducer)
-
-    fun addEvent(uniqueKafkaEventIdentifier: UniqueKafkaEventIdentifier): Boolean {
-        return userEventIds.add(UserEventIdEntry(uniqueKafkaEventIdentifier.fodselsnummer, uniqueKafkaEventIdentifier.eventId))
-    }
-
-    init {
-        userEventIds.add(UserEventIdEntry(initialEntry.fodselsnummer, initialEntry.eventId))
-    }
-}
-
-private data class UserEventIdEntry(
-        val fodselsnummer: String,
-        val eventId: String
-)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/UniqueEventsTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/UniqueEventsTracker.kt
@@ -2,7 +2,7 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 
-class UniqueEventsTracker(private val expectedEventsPerUserPerProducer: Int) {
+class UniqueEventsTracker {
 
     private val perProducerMap = HashMap<String, PerProducerTracker>()
 
@@ -20,7 +20,7 @@ class UniqueEventsTracker(private val expectedEventsPerUserPerProducer: Int) {
 
             isUnique
         } else {
-            perProducerMap[eventIdentifier.systembruker] = PerProducerTracker(eventIdentifier, expectedEventsPerUserPerProducer)
+            perProducerMap[eventIdentifier.systembruker] = PerProducerTracker(eventIdentifier)
             uniqueEventsVar++
             true
         }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
@@ -1,0 +1,47 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
+
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be in`
+import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.Test
+
+internal class FodselsnummerTest {
+    @Test
+    fun `Should use numeric variable to store fodselsnummer if possible`() {
+        val fodselsnummerText = "123456"
+
+        val fodselsnummer = Fodselsnummer.fromString(fodselsnummerText)
+
+        fodselsnummer `should be instance of` FodselsnummerNumeric::class
+        (fodselsnummer as FodselsnummerNumeric).longValue `should be equal to` fodselsnummerText.toLong()
+    }
+
+    @Test
+    fun `Should use string variable to store fodselsnummer it is not possible to parse as number`() {
+        val fodselsnummerText = "abc123"
+
+        val fodselsnummer = Fodselsnummer.fromString(fodselsnummerText)
+
+        fodselsnummer `should be instance of` FodselsnummerString::class
+        (fodselsnummer as FodselsnummerString).stringValue `should be equal to` fodselsnummerText
+    }
+
+    @Test
+    fun `Should work as expected in sets`() {
+        val fodselsnummerNumeric = Fodselsnummer.fromString("123")
+        val fodselsnummerNumericDuplicate = Fodselsnummer.fromString("123")
+        val fodselsnummerString = Fodselsnummer.fromString("abc")
+        val fodselsnummerStringDuplicate = Fodselsnummer.fromString("abc")
+
+        val set = HashSet<Fodselsnummer>()
+
+        set.add(fodselsnummerNumeric)
+        set.add(fodselsnummerNumericDuplicate)
+        set.add(fodselsnummerString)
+        set.add(fodselsnummerStringDuplicate)
+
+        set.size `should be equal to` 2
+        fodselsnummerNumeric `should be in` set
+        fodselsnummerString `should be in` set
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/UniqueEventsTrackerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/UniqueEventsTrackerTest.kt
@@ -1,0 +1,38 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class UniqueEventsTrackerTest {
+    @Test
+    fun `Should handle no events registered`() {
+        val tracker = UniqueEventsTracker()
+
+        tracker.uniqueEvents `should be equal to` 0
+    }
+
+    @Test
+    fun `Should keep track of unique events`() {
+        val eventWithDuplicates1 = (1..3).map { createEvent("123", "srv_one","ab-1") }
+        val eventWithDuplicates2 = (1..2).map { createEvent("123", "srv_one","ab-2") }
+        val eventWithDuplicates3 = (1..3).map { createEvent("456", "srv_one","ab-1") }
+        val producerOneEvents = eventWithDuplicates1 + eventWithDuplicates2 + eventWithDuplicates3
+
+        val eventWithDuplicates4 = (1..4).map { createEvent("123", "srv_two","ab-1") }
+        val eventWithDuplicates5 = (1..1).map { createEvent("123", "srv_two","ab-2") }
+        val eventWithDuplicates6 = (1..5).map { createEvent("456", "srv_two","ab-1") }
+        val producerTwoEvents = eventWithDuplicates4 + eventWithDuplicates5 + eventWithDuplicates6
+
+        val allEvents = producerOneEvents + producerTwoEvents
+
+        val tracker = UniqueEventsTracker()
+
+        allEvents.forEach { tracker.addEvent(it) }
+
+        tracker.uniqueEvents `should be equal to` 6
+    }
+}
+
+private fun createEvent(ident: String, systemBruker: String, eventId: String)
+        = UniqueKafkaEventIdentifier(eventId, systemBruker, ident)


### PR DESCRIPTION
Forbedret minnebruk for tracking av unike eventer.

Så langt er det gjort 2 vesentlige optimaliseringer:

- Grupper eventer etter systembruker. Dette reduserer antall duplikate strenger med flere millioner, og forminsket minnebruken med rundt 400 MB.

- Tolk fodselsnummer som Long-variabel der det er mulig. Dette reduserte minnebruker med ytterligere 100 MB.


Enda en optimalisering som skreller vekk minst 100 MB til finnes i en annen branch, men løsningen er ikke helt moden enda.