### PR TITLE
Memory optimization eventid

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/EventId.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/EventId.kt
@@ -1,0 +1,23 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
+
+interface EventId
+
+data class EventIdString (
+        val stringValue: String
+): EventId
+
+data class EventIdCustomUuid (
+        val prefix: Char,
+        val lowBits: Long,
+        val highBits: Long
+): EventId
+
+data class EventIdUuid (
+        val lowBits: Long,
+        val highBits: Long
+): EventId
+
+data class EventIdUlid (
+        val lowBits: Long,
+        val highBits: Long
+): EventId

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/EventId.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/EventId.kt
@@ -2,17 +2,17 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 interface EventId
 
-data class EventIdString (
+data class EventIdPlainText (
         val stringValue: String
 ): EventId
 
-data class EventIdCustomUuid (
-        val prefix: Char,
+data class EventIdUuid (
         val lowBits: Long,
         val highBits: Long
 ): EventId
 
-data class EventIdUuid (
+data class EventIdPrefixedUuid (
+        val prefix: Char,
         val lowBits: Long,
         val highBits: Long
 ): EventId

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
@@ -9,12 +9,12 @@ interface Fodselsnummer {
             return if (longValue != null) {
                 FodselsnummerNumeric(longValue)
             } else {
-                FodselsnummerString(fodselsnummerString)
+                FodselsnummerPlainText(fodselsnummerString)
             }
         }
     }
 }
 
-data class FodselsnummerString(val stringValue: String): Fodselsnummer
+data class FodselsnummerPlainText(val stringValue: String): Fodselsnummer
 
 data class FodselsnummerNumeric(val longValue: Long): Fodselsnummer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
@@ -12,7 +12,6 @@ interface Fodselsnummer {
                 FodselsnummerString(fodselsnummerString)
             }
         }
-
     }
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.EventIdParser
 
 class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier) {
 
@@ -17,13 +18,13 @@ class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier) {
 
 private data class UserEventIdEntry(
         val fodselsnummer: Fodselsnummer,
-        val eventId: String
+        val eventId: EventId
 ) {
     companion object {
         fun fromUniqueIdentifier(uniqueIdentifier: UniqueKafkaEventIdentifier) =
                 UserEventIdEntry(
                         fodselsnummer = Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer),
-                        eventId =  uniqueIdentifier.eventId
+                        eventId = EventIdParser.parseEventId(uniqueIdentifier.eventId)
                 )
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
@@ -1,0 +1,62 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse
+
+import java.lang.RuntimeException
+
+object Base16Parser {
+    fun parseNumericValueFromBase16(string: String): LongArray {
+
+        if (string.isEmpty()) {
+            return LongArray(0)
+        }
+
+        val numBits = string.length * 4
+
+        val numBytes = (numBits + 7)  / 8
+
+        val cumulativeValue = LongArray((numBytes + 7) / 8)
+
+        var currentVal = 0L
+        var minorIteration = 0
+        var majorIteration = 0
+
+        for (char in string.reversed()) {
+            currentVal += parseBase16Char(char) * (16 `to the power of` minorIteration)
+
+            minorIteration++
+
+
+            if (minorIteration == 16) {
+                cumulativeValue[majorIteration] = currentVal
+
+                currentVal = 0
+                minorIteration = 0
+                majorIteration++
+            }
+        }
+
+        if (minorIteration > 0) {
+            cumulativeValue[majorIteration] = currentVal
+        }
+
+        return cumulativeValue
+    }
+
+    private infix fun Int.`to the power of`(exponent: Int): Long {
+        var cumulative = 1L
+
+        (1..exponent).forEach { _ ->
+            cumulative *= this
+        }
+
+        return cumulative
+    }
+
+    private fun parseBase16Char(char: Char): Int {
+        return when (char) {
+            in '0'..'9' -> char - '0'
+            in 'a'..'f' -> char + 10 - 'a'
+            in 'A'..'F' -> char + 10 - 'A'
+            else -> throw RuntimeException("Kan ikke parse char $char. for base-16")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
@@ -9,7 +9,7 @@ import java.lang.RuntimeException
 // Returarray-et er formatert slik at siffrene lengst til høyre kommer først i array-et. For å illustrere hvordan
 // dette ser ut, kan du se for deg at vi vil sende tallet 123456789 med et array av variabler som kan holde til og med
 // tallet 99. Dette vil sendes på denne måten: [89, 67, 45, 23, 1]
-// Bemerk at java ikke støtter Unsigned primitives. Dette vil si at tall der bit-en helt til venstre er satt vil,
+// Bemerk at java ikke støtter Unsigned primitives. Dette vil si at tall der bit-en helt til venstre er satt, vil
 // vises som negative. Dette er forventet oppførsel.
 object Base16Parser {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
@@ -2,6 +2,15 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import java.lang.RuntimeException
 
+// Denne parser et base-16 tall representert som en String om til sin numeriske verdi.
+// Fordi vi likevel ønsker å sitte igjen med Long variabler, har vi valgt å gjøre en liten optimalisering ved å
+// implementere offsett-logikken selv i stedet for å f. eks. bruke en BigInteger.
+//
+// Returarray-et er formatert slik at siffrene lengst til høyre kommer først i array-et. For å illustrere hvordan
+// dette ser ut, kan du se for deg at vi vil sende tallet 123456789 med et array av variabler som kan holde til og med
+// tallet 99. Dette vil sendes på denne måten: [89, 67, 45, 23, 1]
+// Bemerk at java ikke støtter Unsigned primitives. Dette vil si at tall der bit-en helt til venstre er satt vil,
+// vises som negative. Dette er forventet oppførsel.
 object Base16Parser {
 
     fun parseNumericValueFromBase16(string: String): LongArray {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16Parser.kt
@@ -3,16 +3,20 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 import java.lang.RuntimeException
 
 object Base16Parser {
+
     fun parseNumericValueFromBase16(string: String): LongArray {
 
         if (string.isEmpty()) {
             return LongArray(0)
         }
 
+        // In base-16, each character encodes 4 bits
         val numBits = string.length * 4
 
+        // Bytes needed is number of bits divided 8, rounded up
         val numBytes = (numBits + 7)  / 8
 
+        // Each Long is 8 bytes wide. Thus number of longs needed is also number of bytes divided by 8, rounded up
         val cumulativeValue = LongArray((numBytes + 7) / 8)
 
         var currentVal = 0L
@@ -24,7 +28,8 @@ object Base16Parser {
 
             minorIteration++
 
-
+            // Our current long value is saturated when we have handled 16 characters. Thus we need to store our
+            // current result and prepare for calculating our next long value
             if (minorIteration == 16) {
                 cumulativeValue[majorIteration] = currentVal
 
@@ -33,6 +38,8 @@ object Base16Parser {
                 majorIteration++
             }
         }
+
+        // Store current updated value in return array
 
         if (minorIteration > 0) {
             cumulativeValue[majorIteration] = currentVal

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
@@ -2,6 +2,18 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import java.lang.RuntimeException
 
+// Denne parser et base-32 tall representert som en String om til sin numeriske verdi. Som klassenavnet indikerer
+// støtter denne kun ULID-standarden for base-32. Det vi si at i stedet for å bruke 0-9 og alle bokstaver fom. A tom. V,
+// bruker vi bokstaver fom. A tom. Z, men hopper over I, L, O, og U.
+//
+// Fordi vi likevel ønsker å sitte igjen med Long variabler, har vi valgt å gjøre en liten optimalisering ved å
+// implementere offsett-logikken selv i stedet for å f. eks. bruke en BigInteger.
+//
+// Returarray-et er formatert slik at siffrene lengst til høyre kommer først i array-et. For å illustrere hvordan
+// dette ser ut, kan du se for deg at vi vil sende tallet 123456789 med et array av variabler som kan holde til og med
+// tallet 99. Dette vil sendes på denne måten: [89, 67, 45, 23, 1]
+// Bemerk at java ikke støtter Unsigned primitives. Dette vil si at tall der bit-en helt til venstre er satt vil,
+// vises som negative. Dette er forventet oppførsel.
 object Base32UlidParser {
 
     fun parseNumericValueFromBase32Ulid(string: String): LongArray {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
@@ -1,0 +1,88 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse
+
+import java.lang.RuntimeException
+
+object Base32UlidParser {
+
+    fun parseNumericValueFromBase32Ulid(string: String): LongArray {
+        if (string.isEmpty()) {
+            return LongArray(0)
+        }
+
+        val numBits = string.length * 5
+
+        val numBytes = (numBits + 7)  / 8
+
+        val cumulativeValue = LongArray((numBytes + 7) / 8)
+
+        var currentVal = 0L
+        var minorIteration = 0
+        var majorIteration = 0
+
+        var offset = 0
+        var prevOffset: Int
+        var bitcount = 0
+
+        for (char in string.reversed()) {
+            bitcount += 5
+            if (bitcount % 64 < 5) {
+
+                prevOffset = offset
+                offset = bitcount % 64
+                val offsetInverse = 5 - offset
+
+                val charVal = parseBase32UlidChar(char)
+
+                val highPart = (charVal shr offsetInverse).toLong()
+                val lowPart = charVal - (highPart shl offsetInverse)
+
+                currentVal += lowPart * ((32 `to the power of` minorIteration) * (2 `to the power of` prevOffset))
+
+                cumulativeValue[majorIteration] = currentVal
+                cumulativeValue[majorIteration + 1] = highPart
+
+                currentVal = highPart
+                minorIteration = 0
+                majorIteration++
+            } else {
+                currentVal += parseBase32UlidChar(char) * ((32 `to the power of` minorIteration) * (2 `to the power of` offset))
+
+                minorIteration++
+            }
+        }
+
+        if (minorIteration > 0) {
+            cumulativeValue[majorIteration] = currentVal
+        }
+
+        return cumulativeValue
+    }
+
+    private infix fun Int.`to the power of`(exponent: Int): Long {
+        var cumulative = 1L
+
+        (1..exponent).forEach { _ ->
+            cumulative *= this
+        }
+
+        return cumulative
+    }
+
+    // Account for invalid characters I, L, O and U
+    private fun parseBase32UlidChar(char: Char): Int {
+        return when (char) {
+            in '0'..'9' -> char - '0'
+            in 'a'..'h' -> char + 10 - 'a'
+            in 'A'..'H' -> char + 10 - 'A'
+            in "jk" -> char + 9 - 'a'
+            in "JK" -> char + 9 - 'A'
+            in "mn" -> char + 8 - 'a'
+            in "MN" -> char + 8 - 'A'
+            in 'p'..'t' -> char + 7 - 'a'
+            in 'P'..'T' -> char + 7 - 'A'
+            in 'v'..'z' -> char + 6 - 'a'
+            in 'V'..'Z' -> char + 6 - 'A'
+            else -> throw RuntimeException("Kan ikke parse char $char for base-32 (ULID).")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
@@ -9,10 +9,13 @@ object Base32UlidParser {
             return LongArray(0)
         }
 
+        // In base-32, each character encodes 5 bits
         val numBits = string.length * 5
 
+        // Bytes needed is number of bits divided 8, rounded up
         val numBytes = (numBits + 7)  / 8
 
+        // Each Long is 8 bytes wide. Thus number of longs needed is also number of bytes divided by 8, rounded up
         val cumulativeValue = LongArray((numBytes + 7) / 8)
 
         var currentVal = 0L
@@ -25,32 +28,48 @@ object Base32UlidParser {
 
         for (char in string.reversed()) {
             bitcount += 5
+            // Handle special case when current long value is about to be completely saturated
             if (bitcount % 64 < 5) {
 
+                // Offset determines the cut-off point at which the lower bits are placed in current long variable,
+                // and higher bits are placed in next long variable.
                 prevOffset = offset
                 offset = bitcount % 64
+
+                // Inverse offset is the position of the offset as counted from the left, rather than the right
                 val offsetInverse = 5 - offset
 
                 val charVal = parseBase32UlidChar(char)
 
+                // Let's say our offset is 3, and inverse 2. This makes the bit pattern hhlll. Meaning that the
+                // 3 rightmost bits would be placed at the left end of our current long value, while the 2 leftmost
+                // bits would be placed at the right end of our next long.
                 val highPart = (charVal shr offsetInverse).toLong()
                 val lowPart = charVal - (highPart shl offsetInverse)
 
                 currentVal += lowPart * ((32 `to the power of` minorIteration) * (2 `to the power of` prevOffset))
 
+                // Store current and next longs in return array
                 cumulativeValue[majorIteration] = currentVal
                 cumulativeValue[majorIteration + 1] = highPart
 
+                // Set current long to next long
                 currentVal = highPart
+
+                // Reset minorIteration and increment majorIteration to reflect starting at the beginning of our next long
                 minorIteration = 0
                 majorIteration++
             } else {
+                // Because we have to consider the offset as well as the position of the character, we also have to
+                // multiply the value by 1, 2, 4, 8, or 16, based on our current offset.
                 currentVal += parseBase32UlidChar(char) * ((32 `to the power of` minorIteration) * (2 `to the power of` offset))
 
+                // Increment minorIteration to reflect moving one step left in our current long
                 minorIteration++
             }
         }
 
+        // Store current updated value in return array
         if (minorIteration > 0) {
             cumulativeValue[majorIteration] = currentVal
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParser.kt
@@ -12,7 +12,7 @@ import java.lang.RuntimeException
 // Returarray-et er formatert slik at siffrene lengst til høyre kommer først i array-et. For å illustrere hvordan
 // dette ser ut, kan du se for deg at vi vil sende tallet 123456789 med et array av variabler som kan holde til og med
 // tallet 99. Dette vil sendes på denne måten: [89, 67, 45, 23, 1]
-// Bemerk at java ikke støtter Unsigned primitives. Dette vil si at tall der bit-en helt til venstre er satt vil,
+// Bemerk at java ikke støtter Unsigned primitives. Dette vil si at tall der bit-en helt til venstre er satt, vil
 // vises som negative. Dette er forventet oppførsel.
 object Base32UlidParser {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/EventIdParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/EventIdParser.kt
@@ -1,0 +1,55 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.*
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.Base16Parser.parseNumericValueFromBase16
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.Base32UlidParser.parseNumericValueFromBase32Ulid
+
+object EventIdParser {
+    private const val BASE_16 = "[0-9a-fA-F]"
+
+    private const val BASE_32_ULID = "[0-9ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz]"
+
+    private val UUID_PATTERN = "^$BASE_16{8}-$BASE_16{4}-$BASE_16{4}-$BASE_16{4}-$BASE_16{12}$".toRegex()
+
+    // We know some eventids look like normal uuids prefixed with some character. Handle these separately
+    private val CUSTOM_UUID_PATTERN = "^([a-zA-Z])($BASE_16{8}-$BASE_16{4}-$BASE_16{4}-$BASE_16{4}-$BASE_16{12}$)".toRegex()
+
+    private val ULID_PATTERN = "^[0-7]$BASE_32_ULID{25}$".toRegex()
+
+    fun parseEventId(eventIdString: String): EventId {
+        return when {
+            UUID_PATTERN.matches(eventIdString) -> parseUuid(eventIdString)
+            ULID_PATTERN.matches(eventIdString) -> parseUlid(eventIdString)
+            CUSTOM_UUID_PATTERN.matches(eventIdString) -> parseCustomUuid(eventIdString)
+            else -> EventIdString(stringValue = eventIdString)
+        }
+    }
+
+    private fun parseUuid(uuidString: String): EventId {
+        val withoutHyphen = uuidString.replace("-", "")
+
+        val dataAs128BitNumber = parseNumericValueFromBase16(withoutHyphen)
+
+        return EventIdUuid(lowBits = dataAs128BitNumber[0], highBits = dataAs128BitNumber[1])
+    }
+
+    private fun parseUlid(ulidString: String): EventId {
+        val dataAs128BitNumber = parseNumericValueFromBase32Ulid(ulidString)
+
+        return EventIdUlid(lowBits = dataAs128BitNumber[0], highBits = dataAs128BitNumber[1])
+    }
+
+    private fun parseCustomUuid(eventIdString: String): EventId {
+        return CUSTOM_UUID_PATTERN.find(eventIdString)!!.destructured.let { (prefix, uuidString) ->
+            val withoutHyphen = uuidString.replace("-", "")
+
+            val dataAs128BitNumber = parseNumericValueFromBase16(withoutHyphen)
+
+            EventIdCustomUuid(
+                    prefix = prefix.first(),
+                    lowBits = dataAs128BitNumber[0],
+                    highBits = dataAs128BitNumber[1]
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/EventIdParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/EventIdParser.kt
@@ -7,21 +7,24 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 object EventIdParser {
     private const val BASE_16 = "[0-9a-fA-F]"
 
+    // Base-32 as used in ULIDs use 22 characters in the range A-Z, omitting I, L, O and U
     private const val BASE_32_ULID = "[0-9ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz]"
 
     private val UUID_PATTERN = "^$BASE_16{8}-$BASE_16{4}-$BASE_16{4}-$BASE_16{4}-$BASE_16{12}$".toRegex()
 
     // We know some eventids look like normal uuids prefixed with some character. Handle these separately
-    private val CUSTOM_UUID_PATTERN = "^([a-zA-Z])($BASE_16{8}-$BASE_16{4}-$BASE_16{4}-$BASE_16{4}-$BASE_16{12}$)".toRegex()
+    private val PREFIXED_UUID_PATTERN = "^([a-zA-Z])($BASE_16{8}-$BASE_16{4}-$BASE_16{4}-$BASE_16{4}-$BASE_16{12}$)".toRegex()
 
+    // ULIDs are a total of 128 bits wide, with 5 bits encoded per character. This means that the most leftmost
+    // character is only 3 bits wide (128 mod 5), and can only be in the range 0-7 inclusive.
     private val ULID_PATTERN = "^[0-7]$BASE_32_ULID{25}$".toRegex()
 
     fun parseEventId(eventIdString: String): EventId {
         return when {
             UUID_PATTERN.matches(eventIdString) -> parseUuid(eventIdString)
             ULID_PATTERN.matches(eventIdString) -> parseUlid(eventIdString)
-            CUSTOM_UUID_PATTERN.matches(eventIdString) -> parseCustomUuid(eventIdString)
-            else -> EventIdString(stringValue = eventIdString)
+            PREFIXED_UUID_PATTERN.matches(eventIdString) -> parseCustomUuid(eventIdString)
+            else -> EventIdPlainText(stringValue = eventIdString)
         }
     }
 
@@ -40,12 +43,12 @@ object EventIdParser {
     }
 
     private fun parseCustomUuid(eventIdString: String): EventId {
-        return CUSTOM_UUID_PATTERN.find(eventIdString)!!.destructured.let { (prefix, uuidString) ->
+        return PREFIXED_UUID_PATTERN.find(eventIdString)!!.destructured.let { (prefix, uuidString) ->
             val withoutHyphen = uuidString.replace("-", "")
 
             val dataAs128BitNumber = parseNumericValueFromBase16(withoutHyphen)
 
-            EventIdCustomUuid(
+            EventIdPrefixedUuid(
                     prefix = prefix.first(),
                     lowBits = dataAs128BitNumber[0],
                     highBits = dataAs128BitNumber[1]

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/EventIdParseUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/EventIdParseUtilKtTest.kt
@@ -1,0 +1,70 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.EventIdParser
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.Test
+
+internal class EventIdParseUtilKtTest {
+    @Test
+    fun `Should be able to recognize and parse valid UUIDS`() {
+        val eventIdText = "12345678-1234-abcd-abcd-123456abcdef"
+
+        val eventId = EventIdParser.parseEventId(eventIdText)
+
+        eventId `should be instance of` EventIdUuid::class
+    }
+
+    @Test
+    fun `Should be able to recognize and parse valid UUIDS when prefixed with a single character`() {
+        val eventIdText = "A12345678-1234-abcd-abcd-123456abcdef"
+
+        val eventId = EventIdParser.parseEventId(eventIdText)
+
+        eventId `should be instance of` EventIdPrefixedUuid::class
+
+        (eventId as EventIdPrefixedUuid).prefix `should be equal to` 'A'
+    }
+
+    @Test
+    fun `Should be able to recognize and parse valid ULIDs`() {
+        val eventIdText = "1234ABCDEFGHJKMNPQRSTVWXYZ"
+
+        val eventId = EventIdParser.parseEventId(eventIdText)
+
+        eventId `should be instance of` EventIdUlid::class
+    }
+
+    @Test
+    fun `Should keep string as-is if eventId does not match a recognized format`() {
+        val eventIdText = "customEventId1"
+
+        val eventId = EventIdParser.parseEventId(eventIdText)
+
+        eventId `should be instance of` EventIdPlainText::class
+
+        (eventId as EventIdPlainText).stringValue `should be equal to` eventIdText
+    }
+
+    @Test
+    fun `EventId objects should behave as expected with respect to sets`() {
+        val eventIdsWithDuplicates = listOf(
+            "1245678-1234-abcd-abcd-123456abcdef",
+            "1245678-1234-abcd-abcd-123456abcdef",
+            "A1245678-1234-abcd-abcd-123456abcdef",
+            "A1245678-1234-abcd-abcd-123456abcdef",
+            "1234ABCDEFGHJKMNPQRSTVWXYZ",
+            "1234ABCDEFGHJKMNPQRSTVWXYZ",
+            "customEventId1",
+            "customEventId1"
+        )
+
+        val parsedEventIdSet = HashSet<EventId>()
+
+        eventIdsWithDuplicates.forEach { eventIdString ->
+            parsedEventIdSet.add(EventIdParser.parseEventId(eventIdString))
+        }
+
+        parsedEventIdSet.size `should be equal to` 4
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
@@ -22,8 +22,8 @@ internal class FodselsnummerTest {
 
         val fodselsnummer = Fodselsnummer.fromString(fodselsnummerText)
 
-        fodselsnummer `should be instance of` FodselsnummerString::class
-        (fodselsnummer as FodselsnummerString).stringValue `should be equal to` fodselsnummerText
+        fodselsnummer `should be instance of` FodselsnummerPlainText::class
+        (fodselsnummer as FodselsnummerPlainText).stringValue `should be equal to` fodselsnummerText
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16ParserTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base16ParserTest.kt
@@ -1,0 +1,74 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse
+
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+import java.lang.RuntimeException
+
+internal class Base16ParserTest {
+    @Test
+    fun `Can parse base-16 minimum from 128-bit wide input string`() {
+        val encodedString = "00000000-0000-0000-0000-000000000000".stripHyphen()
+
+        val expectedLow = 0L
+        val expectedHigh = 0L
+
+        val result = Base16Parser.parseNumericValueFromBase16(encodedString)
+
+        result[0] `should be equal to` expectedLow
+        result[1] `should be equal to` expectedHigh
+    }
+    @Test
+    fun `Can parse base-16 maximum from 128-bit wide input value`() {
+        val encodedString = "ffffffff-ffff-ffff-ffff-ffffffffffff".stripHyphen()
+
+        val expectedLow = -1L
+        val expectedHigh = -1L
+
+        val result = Base16Parser.parseNumericValueFromBase16(encodedString)
+
+        result[0] `should be equal to` expectedLow
+        result[1] `should be equal to` expectedHigh
+    }
+
+    @Test
+    fun `Can parse any base-16 value`() {
+        val encodedString = "1234567890abcdef"
+
+        val result = Base16Parser.parseNumericValueFromBase16(encodedString)
+
+        val encodedBits = encodedString.length * 4
+        val expectedLongs = (encodedBits + 63) / 64
+
+        result.size `should be equal to` expectedLongs
+    }
+
+    @Test
+    fun `Mathematics of parsed values should behave as expected`() {
+        val baseValue = "ABC000"
+        val incrementedValue1 = "ABC001"
+        val incrementedValue2 = "ABC010"
+        val incrementedValue3 = "ABC100"
+
+        val baseNumeric = Base16Parser.parseNumericValueFromBase16(baseValue).first()
+        val incrementedNumeric1 = Base16Parser.parseNumericValueFromBase16(incrementedValue1).first()
+        val incrementedNumeric2 = Base16Parser.parseNumericValueFromBase16(incrementedValue2).first()
+        val incrementedNumeric3 = Base16Parser.parseNumericValueFromBase16(incrementedValue3).first()
+
+        (incrementedNumeric1 - baseNumeric) `should be equal to` 1
+        (incrementedNumeric2 - baseNumeric) `should be equal to` 16
+        (incrementedNumeric3 - baseNumeric) `should be equal to` (16 * 16)
+    }
+
+    @Test
+    fun `Should fail on invalid characters`() {
+        ('g'..'z').forEach { char ->
+            invoking {
+                Base16Parser.parseNumericValueFromBase16(char.toString())
+            } `should throw` RuntimeException::class
+        }
+    }
+
+    private fun String.stripHyphen() = replace("-", "")
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParserTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/Base32UlidParserTest.kt
@@ -1,0 +1,73 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse
+
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+import java.lang.RuntimeException
+
+internal class Base32UlidParserTest {
+    @Test
+    fun `Can parse base-32 minimum from ULID string`() {
+        val encodedString = "00000000000000000000000000"
+
+        val expectedLow = 0L
+        val expectedHigh = 0L
+
+        val result = Base32UlidParser.parseNumericValueFromBase32Ulid(encodedString)
+
+        result[0] `should be equal to` expectedLow
+        result[1] `should be equal to` expectedHigh
+    }
+    @Test
+    fun `Can parse base-32 maximum from ULID string`() {
+        val encodedString = "7ZZZZZZZZZZZZZZZZZZZZZZZZZ"
+
+        val expectedLow = -1L
+        val expectedHigh = -1L
+
+        val result = Base32UlidParser.parseNumericValueFromBase32Ulid(encodedString)
+
+        result[0] `should be equal to` expectedLow
+        result[1] `should be equal to` expectedHigh
+    }
+
+    @Test
+    fun `Can parse any base-32 value from ULID string`() {
+        val encodedString = "1234567890ABCDEFGHJKMNPQRSTVWXYZ"
+
+        val result = Base32UlidParser.parseNumericValueFromBase32Ulid(encodedString)
+
+        val encodedBits = encodedString.length * 5
+        val expectedLongs = (encodedBits + 63) / 64
+
+        result.size `should be equal to` expectedLongs
+    }
+
+    @Test
+    fun `Should fail on invalid characters`() {
+
+        "ilouILOU".forEach { char ->
+            invoking {
+                Base32UlidParser.parseNumericValueFromBase32Ulid(char.toString())
+            } `should throw` RuntimeException::class
+        }
+    }
+
+    @Test
+    fun `Mathematics of parsed values should behave as expected`() {
+        val baseValue = "ABC000"
+        val incrementedValue1 = "ABC001"
+        val incrementedValue2 = "ABC010"
+        val incrementedValue3 = "ABC100"
+
+        val baseNumeric = Base32UlidParser.parseNumericValueFromBase32Ulid(baseValue).first()
+        val incrementedNumeric1 = Base32UlidParser.parseNumericValueFromBase32Ulid(incrementedValue1).first()
+        val incrementedNumeric2 = Base32UlidParser.parseNumericValueFromBase32Ulid(incrementedValue2).first()
+        val incrementedNumeric3 = Base32UlidParser.parseNumericValueFromBase32Ulid(incrementedValue3).first()
+
+        (incrementedNumeric1 - baseNumeric) `should be equal to` 1
+        (incrementedNumeric2 - baseNumeric) `should be equal to` 32
+        (incrementedNumeric3 - baseNumeric) `should be equal to` (32 * 32)
+    }
+}


### PR DESCRIPTION
La til enda en vesentlig minneoptimalisering. 

Denne kutter ned minnebruker med ytterligere 300 MB ved å konvertere eventIder til numeriske verdier der det er mulig.

Dette fungerer fordi de fleste produsentene bruker UUID (eller UUID med 1 bokstav ekstra som prefiks). UUID er en 128-bits verdi representert med 32 heksadesimale tegn, med bindestrek for lesbarhet. Dette lar seg konvertere 1:1 over til 2 long verdier, ettersom disse holder 64 bit hver seg.

Det er også lagt til støtte for ULID, med samme grunnlag. Forskjellen er at det her er snakk om konvertering fra base-32 i stedet for base-16 som med UUID. 