### PR TITLE
Workaround fordi appen svelger exceptions fra Kafka.

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/database/kafka/util/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/database/kafka/util/KafkaTestUtil.kt
@@ -47,7 +47,8 @@ object KafkaTestUtil {
                 namespace = "namespaceIkkeIBrukHer",
                 sensuHost = "sensuHostIkkeIBrukHer",
                 sensuPort = 0,
-                countingIntervalMinutes = 1
+                countingIntervalMinutes = 1,
+                maxFailedCounts = 5
         )
     }
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceIT.kt
@@ -55,9 +55,9 @@ class TopicEventCounterServiceIT {
             topicEventTypeCounter.countEventsAsync().await()
         }
 
-        metricsSession.getDuplicates() `should be equal to` events.size * 2
-        metricsSession.getTotalNumber() `should be equal to` events.size * 3
-        metricsSession.getNumberOfUniqueEvents() `should be equal to` events.size
+        metricsSession!!.getDuplicates() `should be equal to` events.size * 2
+        metricsSession!!.getTotalNumber() `should be equal to` events.size * 3
+        metricsSession!!.getNumberOfUniqueEvents() `should be equal to` events.size
 
         runBlocking { beskjedCountConsumer.stop() }
     }
@@ -83,9 +83,9 @@ class TopicEventCounterServiceIT {
             deltaTopicEventTypeCounter.countEventsAsync().await()
         }
 
-        metricsSession.getDuplicates() `should be equal to` events.size * 5
-        metricsSession.getTotalNumber() `should be equal to` events.size * 6
-        metricsSession.getNumberOfUniqueEvents() `should be equal to` events.size
+        metricsSession!!.getDuplicates() `should be equal to` events.size * 5
+        metricsSession!!.getTotalNumber() `should be equal to` events.size * 6
+        metricsSession!!.getNumberOfUniqueEvents() `should be equal to` events.size
 
         runBlocking { beskjedCountConsumer.stop() }
     }
@@ -127,9 +127,9 @@ class TopicEventCounterServiceIT {
             fromScratchTopicEventTypeCounter.countEventsAsync().await()
         }
 
-        deltaMetricsSession.getDuplicates() `should be equal to` fromScratchMetricsSession.getDuplicates()
-        deltaMetricsSession.getTotalNumber() `should be equal to` fromScratchMetricsSession.getTotalNumber()
-        deltaMetricsSession.getNumberOfUniqueEvents() `should be equal to` fromScratchMetricsSession.getNumberOfUniqueEvents()
+        deltaMetricsSession!!.getDuplicates() `should be equal to` fromScratchMetricsSession!!.getDuplicates()
+        deltaMetricsSession!!.getTotalNumber() `should be equal to` fromScratchMetricsSession!!.getTotalNumber()
+        deltaMetricsSession!!.getNumberOfUniqueEvents() `should be equal to` fromScratchMetricsSession!!.getNumberOfUniqueEvents()
 
         runBlocking {
             deltaCountingConsumer.stop()
@@ -172,7 +172,7 @@ class TopicEventCounterServiceIT {
             topicEventTypeCounter.countEventsAsync().await()
         }
 
-        metricsSession.getNumberOfUniqueEvents() `should be equal to` events.size
+        metricsSession!!.getNumberOfUniqueEvents() `should be equal to` events.size
     }
 
     private fun `Produser det samme settet av eventer tre ganger`(topic: String) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/Consumer.kt
@@ -20,6 +20,7 @@ class Consumer<T>(
 ) : CoroutineScope, HealthCheck {
 
     private val log: Logger = LoggerFactory.getLogger(Consumer::class.java)
+    private var numberOfFailedCounts = 0
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + job
@@ -49,5 +50,17 @@ class Consumer<T>(
     fun startSubscription() {
         log.info("Starter en subscription på topic: $topic.")
         kafkaConsumer.subscribe(listOf(topic))
+    }
+
+    fun getNumberOfFailedCounts(): Int {
+        return numberOfFailedCounts
+    }
+
+    fun countNumberOfFailedCounts() {
+        numberOfFailedCounts++
+    }
+
+    fun resetNumberOfFailedCounts() {
+        numberOfFailedCounts = 0
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/polling/PeriodicConsumerCheck.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/polling/PeriodicConsumerCheck.kt
@@ -42,20 +42,20 @@ class PeriodicConsumerCheck(
     fun getConsumersThatHaveStopped(): MutableList<EventType> {
         val stoppedConsumers = mutableListOf<EventType>()
 
-        if (appContext.beskjedCountConsumer.isStopped()) {
+        if (appContext.beskjedCountConsumer.isStopped() || appContext.beskjedCountConsumer.getNumberOfFailedCounts() > appContext.environment.maxFailedCounts) {
             stoppedConsumers.add(EventType.BESKJED)
         }
-        if (appContext.doneCountConsumer.isStopped()) {
+        if (appContext.doneCountConsumer.isStopped() || appContext.doneCountConsumer.getNumberOfFailedCounts() > appContext.environment.maxFailedCounts) {
             stoppedConsumers.add(EventType.DONE)
         }
-        if (appContext.oppgaveCountConsumer.isStopped()) {
+        if (appContext.oppgaveCountConsumer.isStopped() || appContext.oppgaveCountConsumer.getNumberOfFailedCounts() > appContext.environment.maxFailedCounts) {
             stoppedConsumers.add(EventType.OPPGAVE)
         }
         return stoppedConsumers
     }
 
     suspend fun restartConsumers(stoppedConsumers: MutableList<EventType>) {
-        log.warn("Følgende konsumere hadde stoppet ${stoppedConsumers}, de(n) vil bli restartet.")
+        log.warn("Følgende konsumere hadde stoppet eller klarte ikke å telle eventer: ${stoppedConsumers}, de(n) vil bli restartet.")
         KafkaConsumerSetup.restartConsumers(appContext)
         log.info("$stoppedConsumers konsumern(e) har blitt restartet.")
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
@@ -22,7 +22,8 @@ data class Environment(val bootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP
                        val sensuPort: Int = getEnvVarAsInt("SENSU_PORT"),
                        val deltaCountingEnabled: Boolean = getEnvVarAsBoolean("DELTA_COUNTING_ENABLED", false),
                        val groupIdBase: String = "dn-periodic_metrics_reporter",
-                       val countingIntervalMinutes: Long = getEnvVarAsLong("COUNTING_INTERVAL_MINUTES")
+                       val countingIntervalMinutes: Long = getEnvVarAsLong("COUNTING_INTERVAL_MINUTES"),
+                       val maxFailedCounts: Int = getEnvVarAsInt("MAX_FAILED_COUNTS")
 )
 
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
@@ -6,8 +6,10 @@ class CountingMetricsSessions {
 
     private val sessions = mutableMapOf<EventType, CountingMetricsSession>()
 
-    fun put(eventType: EventType, session: CountingMetricsSession) {
-        sessions[eventType] = session
+    fun put(eventType: EventType, session: CountingMetricsSession?) {
+        if (session != null) {
+            sessions[eventType] = session
+        }
     }
 
     fun totalUniqueEvents(): Int {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/ConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/ConsumerTest.kt
@@ -19,6 +19,7 @@ import java.time.Duration
 class ConsumerTest {
 
     private val kafkaConsumer = mockk<KafkaConsumer<Nokkel, Beskjed>>(relaxUnitFun = true)
+    private val topic = "dummyTopic"
 
     companion object {
         private val defaultMaxPollTimeout = Duration.ofMillis(5000)
@@ -46,5 +47,27 @@ class ConsumerTest {
             consumer.status().status `should be equal to` Status.OK
             consumer.stop()
         }
+    }
+
+    @Test
+    fun `Skal telle antall ganger konsumer ikke klarte aa telle eventer`() {
+        val consumer: Consumer<Beskjed> = Consumer(topic, kafkaConsumer)
+
+        consumer.countNumberOfFailedCounts()
+        consumer.countNumberOfFailedCounts()
+
+        consumer.getNumberOfFailedCounts() `should be equal to` 2
+    }
+
+    @Test
+    fun `Skal resette antall ganger konsumer ikke klarte aa telle eventer`() {
+        val consumer: Consumer<Beskjed> = Consumer(topic, kafkaConsumer)
+
+        consumer.countNumberOfFailedCounts()
+        consumer.countNumberOfFailedCounts()
+
+        consumer.resetNumberOfFailedCounts()
+
+        consumer.getNumberOfFailedCounts() `should be equal to` 0
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/EnvironmentTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/EnvironmentTest.kt
@@ -18,7 +18,8 @@ internal class EnvironmentTest {
         "NAIS_NAMESPACE" to "namespace",
         "SENSU_HOST" to "sensu_host",
         "SENSU_PORT" to "1",
-        "COUNTING_INTERVAL_MINUTES" to "1"
+        "COUNTING_INTERVAL_MINUTES" to "1",
+        "MAX_FAILED_COUNTS" to "1"
     )
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounterTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounterTest.kt
@@ -1,9 +1,6 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.slot
+import io.mockk.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.brukernotifikasjon.schemas.Nokkel
@@ -30,6 +27,11 @@ internal class TopicEventTypeCounterTest {
         val deltaCountingEnabled = true
         val counter = TopicEventTypeCounter(consumer, EventType.BESKJED, deltaCountingEnabled)
 
+        coEvery { consumer.isStopped() } returns false
+        coEvery { consumer.stop() } returns Unit
+        coEvery { consumer.countNumberOfFailedCounts() } returns Unit
+        coEvery { consumer.getNumberOfFailedCounts() } returns 0
+        coEvery { consumer.resetNumberOfFailedCounts() } returns Unit
         every { consumer.kafkaConsumer.poll(any<Duration>()) } returns polledEvents
         every { polledEvents.isEmpty } returns true
 
@@ -49,6 +51,6 @@ internal class TopicEventTypeCounterTest {
             counter.countEventsAsync().await()
         }
 
-        session.getProcessingTime() `should be greater than` minimumProcessingTimeInNs
+        session!!.getProcessingTime() `should be greater than` minimumProcessingTimeInNs
     }
 }


### PR DESCRIPTION
Jeg synes det var litt vanskelig å få dette pent i og med det er en workaround 🙈  Så kom gjerne med tilbakemeldinger! 

Når appen får inn 0 eventer fra Kafka x antall ganger vil appen stoppe konsumerne. Når konsumerne er stoppet vil `PeriodicConsumerCheck` kunne restarte de automatisk. 

I `prod` tenkte jeg å sette `MAX_FAILED_COUNTS` til 60. I og med appen teller hvert minutt vil den restarte konsumerne etter 1 time hvis ikke den har klart å få inn noen eventer. Litt usikker på hva intervallet burde være i `dev` 🤔  Der kan det gå en stund før den får inn eventer.... 
