### PR TITLE
Øker timeout-ene som blir brukt når konsumerne henter eventer fra Kafka.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounter.kt
@@ -24,8 +24,8 @@ class TopicEventTypeCounter(
     private var previousSession: TopicMetricsSession? = null
 
     private val timeoutConfig = TimeoutConfig(
-            initialTimeout = Duration.ofMillis(5000),
-            regularTimeut = Duration.ofMillis(250),
+            initialTimeout = Duration.ofMillis(9000),
+            regularTimeut = Duration.ofMillis(1000),
             maxTotalTimeout = Duration.ofMinutes(3)
     )
 


### PR DESCRIPTION
Teori: Prosesseringen av batch tar lengre tid enn timeout-ene er satt til. 