### PR TITLE
Unntak for Feilrespons, rapportere selv om antallet er lavere enn forrige telling

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
@@ -5,7 +5,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.database.Database
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.polling.PeriodicConsumerCheck
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.HealthService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.DbEventCounterGCPService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterGCPService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameScrubber
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsProbe

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessions.kt
@@ -10,14 +10,6 @@ class CountingMetricsSessions {
         sessions[eventType] = session
     }
 
-    fun totalUniqueEvents(): Int {
-        var total = 0
-        sessions.forEach { (_, session: CountingMetricsSession) ->
-            total += session.getNumberOfUniqueEvents()
-        }
-        return total
-    }
-
     fun getEventTypesWithSession(): Set<EventType> {
         return sessions.keys
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbEventCounterGCPService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbEventCounterGCPService.kt
@@ -1,12 +1,10 @@
-package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsProbe
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsSession
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.MetricsRepository
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessions
 import org.slf4j.LoggerFactory
 
 class DbEventCounterGCPService(

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
@@ -74,4 +74,16 @@ object CountingMetricsSessionsObjectMother {
             put(EventType.STATUSOPPDATERING, TopicMetricsSessionObjectMother.giveMeStatusoppdateringSessionWithOneCountedEvent())
         }
     }
+
+    fun giveMeTopicSessionsWithSingleEventForFeilrespons(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.FEILRESPONS, TopicMetricsSessionObjectMother.giveMeFeilresponsSessionWithOneCountedEvent())
+        }
+    }
+
+    fun giveMeTopicSessionsWithFiveEventsForFeilrespons(): CountingMetricsSessions {
+        return CountingMetricsSessions().apply {
+            put(EventType.FEILRESPONS, TopicMetricsSessionObjectMother.giveMeFeilresponsSessionWithFiveCountedEvent())
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSessionObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicMetricsSessionObjectMother.kt
@@ -152,4 +152,20 @@ object TopicMetricsSessionObjectMother {
         statusoppdateringSession.countEvent(UniqueKafkaEventIdentifier("65", "sysBruker", "123"))
         return statusoppdateringSession
     }
+
+    fun giveMeFeilresponsSessionWithOneCountedEvent(): TopicMetricsSession {
+        val feilresponsSession = TopicMetricsSession(EventType.FEILRESPONS)
+        feilresponsSession.countEvent(UniqueKafkaEventIdentifier.createEventWithoutValidFnr("71", "sysBruker",))
+        return feilresponsSession
+    }
+
+    fun giveMeFeilresponsSessionWithFiveCountedEvent(): TopicMetricsSession {
+        val feilresponsSession = TopicMetricsSession(EventType.FEILRESPONS)
+        feilresponsSession.countEvent(UniqueKafkaEventIdentifier.createEventWithoutValidFnr("71", "sysBruker"))
+        feilresponsSession.countEvent(UniqueKafkaEventIdentifier.createEventWithoutValidFnr("72", "sysBruker"))
+        feilresponsSession.countEvent(UniqueKafkaEventIdentifier.createEventWithoutValidFnr("73", "sysBruker"))
+        feilresponsSession.countEvent(UniqueKafkaEventIdentifier.createEventWithoutValidFnr("74", "sysBruker"))
+        feilresponsSession.countEvent(UniqueKafkaEventIdentifier.createEventWithoutValidFnr("75", "sysBruker"))
+        return feilresponsSession
+    }
 }


### PR DESCRIPTION
Dette trengs da feilrespons-topic-en har kort retention-tid, og at antallet eventer på denne topic-en naturlig vil kunne reduseres uten at det er en tellefeil.