### PR TITLE
Fjernet unødvendig error-logging

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/Consumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/kafka/Consumer.kt
@@ -40,7 +40,7 @@ class Consumer<K, V>(
         return if (job.isActive) {
             HealthStatus(serviceName, Status.OK, "Consumer is running", includeInReadiness = false)
         } else {
-            log.error("Selftest mot Kafka-consumere feilet, consumer kjører ikke.")
+            log.info("Selftest mot Kafka-consumere feilet, consumer kjører ikke. Vil startes igjen av PeriodicConsumerPollingCheck innen 30 minutter.")
             HealthStatus(serviceName, Status.ERROR, "Consumer is not running", includeInReadiness = false)
         }
     }


### PR DESCRIPTION
Dette logginnslaget blir trigget annenhvert sekund av appens readiness-sjekk, selv om selve denne sjekken ikke blir regnet med i readiness-statusen for appen. Dette er ikke noe vi trenger å agere på, og kan derfor logges på info-nivå. Appens coroutine med `PeriodicConsumerPollingCheck` vil hver halvtime sørge for å restarte consumere som har stoppet. Gjorde dette også tydligere i selve logginnslaget.