### PR TITLE
Fix counting block

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/database/kafka/util/KafkaTestUtil.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/common/database/kafka/util/KafkaTestUtil.kt
@@ -42,7 +42,16 @@ object KafkaTestUtil {
                 aivenCredstorePassword = "aivenCredstorePasswordIkkeIBrukHer",
                 aivenSchemaRegistry = embeddedEnv.schemaRegistry!!.url,
                 aivenSchemaRegistryUser = username,
-                aivenSchemaRegistryPassword = password
+                aivenSchemaRegistryPassword = password,
+                lowActivityStreakThreshold = 60,
+                moderateActivityStreakThreshold = 15,
+                highActivityStreakThreshold = 5,
+                monitorOnPremBeskjedActivity = false,
+                monitorOnPremOppgaveActivity = false,
+                monitorOnPremInnboksActivity = false,
+                monitorOnPremDoneActivity = false,
+                monitorOnPremStatusoppdateringActivity = false
+
         )
     }
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterAivenServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterAivenServiceIT.kt
@@ -1,5 +1,7 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
+import io.mockk.clearMocks
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -24,7 +26,7 @@ class TopicEventCounterAivenServiceIT {
     private val topic = "topic"
     private lateinit var embeddedEnv: KafkaEnvironment
     private lateinit var testEnvironment: Environment
-    private val topicActivityService: TopicActivityService = mockk()
+    private val topicActivityService =  TopicActivityService(30)
 
     private val events = (1..5).map { AvroNokkelInternObjectMother.createNokkelIntern(it) to AvroBeskjedInternObjectMother.createBeskjedIntern() }.toMap()
 

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterAivenServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterAivenServiceIT.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
+import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
@@ -10,6 +11,7 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.Environment
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.Kafka
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.KafkaConsumerSetup
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.nokkel.AvroNokkelInternObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.apache.avro.generic.GenericRecord
@@ -22,6 +24,7 @@ class TopicEventCounterAivenServiceIT {
     private val topic = "topic"
     private lateinit var embeddedEnv: KafkaEnvironment
     private lateinit var testEnvironment: Environment
+    private val topicActivityService: TopicActivityService = mockk()
 
     private val events = (1..5).map { AvroNokkelInternObjectMother.createNokkelIntern(it) to AvroBeskjedInternObjectMother.createBeskjedIntern() }.toMap()
 
@@ -48,6 +51,7 @@ class TopicEventCounterAivenServiceIT {
 
         val topicEventTypeCounter = TopicEventTypeCounter(
             consumer = beskjedInternCountConsumer,
+            topicActivityService = topicActivityService,
             eventType = EventType.BESKJED_INTERN,
             deltaCountingEnabled = false
         )
@@ -71,6 +75,7 @@ class TopicEventCounterAivenServiceIT {
 
         val deltaTopicEventTypeCounter = TopicEventTypeCounter(
             consumer = beskjedInternCountConsumer,
+            topicActivityService = topicActivityService,
             eventType = EventType.BESKJED_INTERN,
             deltaCountingEnabled = true
         )
@@ -108,11 +113,13 @@ class TopicEventCounterAivenServiceIT {
 
         val deltaTopicEventTypeCounter = TopicEventTypeCounter(
             consumer = deltaCountingConsumer,
+            topicActivityService = topicActivityService,
             eventType = EventType.BESKJED_INTERN,
             deltaCountingEnabled = true
         )
         val fromScratchTopicEventTypeCounter = TopicEventTypeCounter(
             consumer = fromScratchCountingConsumer,
+            topicActivityService = topicActivityService,
             eventType = EventType.BESKJED_INTERN,
             deltaCountingEnabled = false
         )
@@ -149,6 +156,7 @@ class TopicEventCounterAivenServiceIT {
 
         val topicEventTypeCounter = TopicEventTypeCounter(
             consumer = beskjedCountConsumer,
+            topicActivityService = topicActivityService,
             eventType = EventType.BESKJED_INTERN,
             deltaCountingEnabled = false
         )

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterOnPremServiceIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterOnPremServiceIT.kt
@@ -1,5 +1,7 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.brukernotifikasjon.schemas.Nokkel
@@ -10,6 +12,7 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.Environment
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.Kafka
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.KafkaConsumerSetup
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.nokkel.AvroNokkelObjectMother.createNokkel
 import org.amshove.kluent.`should be equal to`
 import org.apache.avro.generic.GenericRecord
@@ -22,6 +25,7 @@ class TopicEventCounterOnPremServiceIT {
     private val topic = "topic"
     private lateinit var embeddedEnv: KafkaEnvironment
     private lateinit var testEnvironment: Environment
+    private val activityService: TopicActivityService = mockk()
 
     private val events = (1..5).map { createNokkel(it) to AvroBeskjedObjectMother.createBeskjed(it) }.toMap()
 
@@ -46,8 +50,12 @@ class TopicEventCounterOnPremServiceIT {
         val beskjedCountConsumer = KafkaConsumerSetup.setupCountConsumer<Nokkel, GenericRecord>(kafkaProps, topic)
         beskjedCountConsumer.startSubscription()
 
+        every { activityService.reportEventsFound() } returns Unit
+        every { activityService.reportNoEventsFound() } returns Unit
+
         val topicEventTypeCounter = TopicEventTypeCounter(
                 consumer = beskjedCountConsumer,
+                topicActivityService = activityService,
                 eventType = EventType.BESKJED,
                 deltaCountingEnabled = false
         )
@@ -69,8 +77,12 @@ class TopicEventCounterOnPremServiceIT {
         val beskjedCountConsumer = KafkaConsumerSetup.setupCountConsumer<Nokkel, GenericRecord>(kafkaProps, topic)
         beskjedCountConsumer.startSubscription()
 
+        every { activityService.reportEventsFound() } returns Unit
+        every { activityService.reportNoEventsFound() } returns Unit
+
         val deltaTopicEventTypeCounter = TopicEventTypeCounter(
                 consumer = beskjedCountConsumer,
+                topicActivityService = activityService,
                 eventType = EventType.BESKJED,
                 deltaCountingEnabled = true
         )
@@ -104,13 +116,18 @@ class TopicEventCounterOnPremServiceIT {
         val fromScratchCountingConsumer = KafkaConsumerSetup.setupCountConsumer<Nokkel, GenericRecord>(kafkaPropsFromScratchCounting, topic)
         fromScratchCountingConsumer.startSubscription()
 
+        every { activityService.reportEventsFound() } returns Unit
+        every { activityService.reportNoEventsFound() } returns Unit
+
         val deltaTopicEventTypeCounter = TopicEventTypeCounter(
                 consumer = deltaCountingConsumer,
+                topicActivityService = activityService,
                 eventType = EventType.BESKJED,
                 deltaCountingEnabled = true
         )
         val fromScratchTopicEventTypeCounter = TopicEventTypeCounter(
                 consumer = fromScratchCountingConsumer,
+                topicActivityService = activityService,
                 eventType = EventType.BESKJED,
                 deltaCountingEnabled = false
         )
@@ -145,8 +162,12 @@ class TopicEventCounterOnPremServiceIT {
         val beskjedCountConsumer = KafkaConsumerSetup.setupCountConsumer<Nokkel, GenericRecord>(kafkaProps, topic)
         beskjedCountConsumer.startSubscription()
 
+        every { activityService.reportEventsFound() } returns Unit
+        every { activityService.reportNoEventsFound() } returns Unit
+
         val topicEventTypeCounter = TopicEventTypeCounter(
                 consumer = beskjedCountConsumer,
+                topicActivityService = activityService,
                 eventType = EventType.BESKJED,
                 deltaCountingEnabled = false
         )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
@@ -5,6 +5,7 @@ import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.database.Database
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.polling.PeriodicConsumerCheck
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityHealthService
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityHealthServiceConfig
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.HealthService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterGCPService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
@@ -179,15 +180,24 @@ class ApplicationContext {
         kafkaMetricsReporter = kafkaMetricsReporter
     )
 
+    val activityHealthServiceConfig = ActivityHealthServiceConfig(
+            lowActivityStreakThreshold = environment.lowActivityStreakThreshold,
+            moderateActivityStreakThreshold = environment.moderateActivityStreakThreshold,
+            highActivityStreakThreshold = environment.highActivityStreakThreshold,
+            monitorOnPremBeskjedActivity = environment.monitorOnPremBeskjedActivity,
+            monitorOnPremOppgaveActivity = environment.monitorOnPremOppgaveActivity,
+            monitorOnPremInnboksActivity = environment.monitorOnPremInnboksActivity,
+            monitorOnPremDoneActivity = environment.monitorOnPremDoneActivity,
+            monitorOnPremStatusOppdateringActivity = environment.monitorOnPremStatusOppdateringActivity
+    )
+
     val activityHealthService = ActivityHealthService(
             beskjedTopicActivityService = beskjedTopicActivityService,
             oppgaveTopicActivityService = oppgaveTopicActivityService,
             innboksTopicActivityService = innboksTopicActivityService,
             doneTopicActivityService = doneTopicActivityService,
             statusoppdateringTopicActivityService = statusoppdateringTopicActivityService,
-            lowActivityStreakThreshold = environment.lowActivityStreakThreshold,
-            moderateActivityStreakThreshold = environment.moderateActivityStreakThreshold,
-            highActivityStreakThreshold = environment.highActivityStreakThreshold
+            config = activityHealthServiceConfig
     )
 
     var periodicMetricsSubmitter = initializePeriodicMetricsSubmitter()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
@@ -4,8 +4,9 @@ import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.database.Database
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.polling.PeriodicConsumerCheck
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityHealthDecider
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityHealthService
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityHealthServiceConfig
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityMonitoringToggles
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.HealthService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterGCPService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
@@ -180,15 +181,18 @@ class ApplicationContext {
         kafkaMetricsReporter = kafkaMetricsReporter
     )
 
-    val activityHealthServiceConfig = ActivityHealthServiceConfig(
-            lowActivityStreakThreshold = environment.lowActivityStreakThreshold,
-            moderateActivityStreakThreshold = environment.moderateActivityStreakThreshold,
-            highActivityStreakThreshold = environment.highActivityStreakThreshold,
+    val activityHealthServiceConfig = ActivityMonitoringToggles(
             monitorOnPremBeskjedActivity = environment.monitorOnPremBeskjedActivity,
             monitorOnPremOppgaveActivity = environment.monitorOnPremOppgaveActivity,
             monitorOnPremInnboksActivity = environment.monitorOnPremInnboksActivity,
             monitorOnPremDoneActivity = environment.monitorOnPremDoneActivity,
-            monitorOnPremStatusOppdateringActivity = environment.monitorOnPremStatusOppdateringActivity
+            monitorOnPremStatusoppdateringActivity = environment.monitorOnPremStatusoppdateringActivity
+    )
+
+    val activityHealthDecider = ActivityHealthDecider(
+            lowActivityStreakThreshold = environment.lowActivityStreakThreshold,
+            moderateActivityStreakThreshold = environment.moderateActivityStreakThreshold,
+            highActivityStreakThreshold = environment.highActivityStreakThreshold
     )
 
     val activityHealthService = ActivityHealthService(
@@ -197,7 +201,8 @@ class ApplicationContext {
             innboksTopicActivityService = innboksTopicActivityService,
             doneTopicActivityService = doneTopicActivityService,
             statusoppdateringTopicActivityService = statusoppdateringTopicActivityService,
-            config = activityHealthServiceConfig
+            activityHealthDecider = activityHealthDecider,
+            monitoringToggles = activityHealthServiceConfig
     )
 
     var periodicMetricsSubmitter = initializePeriodicMetricsSubmitter()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/ApplicationContext.kt
@@ -4,6 +4,7 @@ import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.database.Database
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.polling.PeriodicConsumerCheck
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.ActivityHealthService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.health.HealthService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterGCPService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.ProducerNameResolver
@@ -16,6 +17,7 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterOnPremService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventTypeCounter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicMetricsReporter
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.resolveMetricsReporter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter.MetricsSubmitterService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.submitter.PeriodicMetricsSubmitter
@@ -50,94 +52,105 @@ class ApplicationContext {
     val beskjedKafkaPropsAiven = Kafka.counterConsumerAivenProps(environment, EventType.BESKJED_INTERN)
     var beskjedCountOnPremConsumer = initializeCountConsumerOnPrem(beskjedKafkaPropsOnPrem, Kafka.beskjedTopicNameOnPrem)
     var beskjedCountAivenConsumer = initializeCountConsumerAiven(beskjedKafkaPropsAiven, Kafka.beskjedTopicNameAiven)
+    val beskjedTopicActivityService = TopicActivityService(environment.activityHistoryLength)
+    val beskjedAivenTopicActivityService = TopicActivityService(environment.activityHistoryLength)
     val beskjedCounterOnPrem = TopicEventTypeCounter(
         beskjedCountOnPremConsumer,
+        beskjedTopicActivityService,
         EventType.BESKJED,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+        environment.deltaCountingEnabled
     )
     val beskjedCounterAiven = TopicEventTypeCounter(
         beskjedCountAivenConsumer,
+        beskjedAivenTopicActivityService,
         EventType.BESKJED_INTERN,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+        environment.deltaCountingEnabled
     )
 
     val oppgaveKafkaPropsOnPrem = Kafka.counterConsumerOnPremProps(environment, EventType.OPPGAVE)
     val oppgaveKafkaPropsAiven = Kafka.counterConsumerAivenProps(environment, EventType.OPPGAVE_INTERN)
     var oppgaveCountOnPremConsumer = initializeCountConsumerOnPrem(oppgaveKafkaPropsOnPrem, Kafka.oppgaveTopicNameOnPrem)
     var oppgaveCountAivenConsumer = initializeCountConsumerAiven(oppgaveKafkaPropsAiven, Kafka.oppgaveTopicNameAiven)
+    val oppgaveTopicActivityService = TopicActivityService(environment.activityHistoryLength)
+    val oppgaveAivenTopicActivityService = TopicActivityService(environment.activityHistoryLength)
     val oppgaveCounterOnPrem = TopicEventTypeCounter(
-        oppgaveCountOnPremConsumer,
-        EventType.OPPGAVE,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            oppgaveCountOnPremConsumer,
+            oppgaveTopicActivityService,
+            EventType.OPPGAVE,
+            environment.deltaCountingEnabled
     )
     val oppgaveCounterAiven = TopicEventTypeCounter(
-        oppgaveCountAivenConsumer,
-        EventType.OPPGAVE_INTERN,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            oppgaveCountAivenConsumer,
+            oppgaveAivenTopicActivityService,
+            EventType.OPPGAVE_INTERN,
+            environment.deltaCountingEnabled
     )
 
     val innboksKafkaPropsOnPrem = Kafka.counterConsumerOnPremProps(environment, EventType.INNBOKS)
     val innboksKafkaPropsAiven = Kafka.counterConsumerAivenProps(environment, EventType.INNBOKS_INTERN)
     var innboksCountOnPremConsumer = initializeCountConsumerOnPrem(innboksKafkaPropsOnPrem, Kafka.innboksTopicNameOnPrem)
     var innboksCountAivenConsumer = initializeCountConsumerAiven(innboksKafkaPropsAiven, Kafka.innboksTopicNameAiven)
+    val innboksTopicActivityService = TopicActivityService(environment.activityHistoryLength)
+    val innboksAivenTopicActivityService = TopicActivityService(environment.activityHistoryLength)
     val innboksCounterOnPrem = TopicEventTypeCounter(
-        innboksCountOnPremConsumer,
-        EventType.INNBOKS,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            innboksCountOnPremConsumer,
+            innboksTopicActivityService,
+            EventType.INNBOKS,
+            environment.deltaCountingEnabled
     )
     val innboksCounterAiven = TopicEventTypeCounter(
-        innboksCountAivenConsumer,
-        EventType.INNBOKS_INTERN,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            innboksCountAivenConsumer,
+            innboksAivenTopicActivityService,
+            EventType.INNBOKS_INTERN,
+            environment.deltaCountingEnabled
     )
 
     val statusoppdateringKafkaPropsOnPrem = Kafka.counterConsumerOnPremProps(environment, EventType.STATUSOPPDATERING)
     val statusoppdateringKafkaPropsAiven = Kafka.counterConsumerAivenProps(environment, EventType.STATUSOPPDATERING_INTERN)
     var statusoppdateringCountOnPremConsumer = initializeCountConsumerOnPrem(statusoppdateringKafkaPropsOnPrem, Kafka.statusoppdateringTopicNameOnPrem)
     var statusoppdateringCountAivenConsumer = initializeCountConsumerAiven(statusoppdateringKafkaPropsAiven, Kafka.statusoppdateringTopicNameAiven)
+    val statusoppdateringTopicActivityService = TopicActivityService(environment.activityHistoryLength)
+    val statusoppdateringAivenTopicActivityService = TopicActivityService(environment.activityHistoryLength)
     val statusoppdateringCounterOnPrem = TopicEventTypeCounter(
-        statusoppdateringCountOnPremConsumer,
-        EventType.STATUSOPPDATERING,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            statusoppdateringCountOnPremConsumer,
+            statusoppdateringTopicActivityService,
+            EventType.STATUSOPPDATERING,
+            environment.deltaCountingEnabled
     )
     val statusoppdateringCounterAiven = TopicEventTypeCounter(
-        statusoppdateringCountAivenConsumer,
-        EventType.STATUSOPPDATERING_INTERN,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            statusoppdateringCountAivenConsumer,
+            statusoppdateringAivenTopicActivityService,
+            EventType.STATUSOPPDATERING_INTERN,
+            environment.deltaCountingEnabled
     )
 
     val doneKafkaPropsOnPrem = Kafka.counterConsumerOnPremProps(environment, EventType.DONE)
     val doneKafkaPropsAiven = Kafka.counterConsumerAivenProps(environment, EventType.DONE_INTERN)
     var doneCountOnPremConsumer = initializeCountConsumerOnPrem(doneKafkaPropsOnPrem, Kafka.doneTopicNameOnPrem)
     var doneCountAivenConsumer = initializeCountConsumerAiven(doneKafkaPropsAiven, Kafka.doneTopicNameAiven)
+    val doneTopicActivityService = TopicActivityService(environment.activityHistoryLength)
+    val doneAivenTopicActivityService = TopicActivityService(environment.activityHistoryLength)
     val doneCounterOnPrem = TopicEventTypeCounter(
-        doneCountOnPremConsumer,
-        EventType.DONE,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            doneCountOnPremConsumer,
+            doneTopicActivityService,
+            EventType.DONE,
+            environment.deltaCountingEnabled
     )
     val doneCounterAiven = TopicEventTypeCounter(
-        doneCountAivenConsumer,
-        EventType.DONE_INTERN,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+            doneCountAivenConsumer,
+            doneAivenTopicActivityService,
+            EventType.DONE_INTERN,
+            environment.deltaCountingEnabled
     )
 
     val feilresponsKafkaPropsAiven = Kafka.counterConsumerAivenProps(environment, EventType.FEILRESPONS)
     var feilresponsCountAivenConsumer = initializeCountConsumerAiven(feilresponsKafkaPropsAiven, Kafka.feilresponsTopicNameAiven)
+    val feilresponsAivenTopicActivityService = TopicActivityService(environment.activityHistoryLength)
     val feilresponsCounterAiven = TopicEventTypeCounter(
         feilresponsCountAivenConsumer,
+        feilresponsAivenTopicActivityService,
         EventType.FEILRESPONS,
-        environment.deltaCountingEnabled,
-        environment.requireEventsInFirstBatch
+        environment.deltaCountingEnabled
     )
 
     val topicEventCounterServiceOnPrem = TopicEventCounterOnPremService(
@@ -164,6 +177,17 @@ class ApplicationContext {
         topicEventCounterServiceAiven = topicEventCounterServiceAiven,
         dbMetricsReporter = dbMetricsReporter,
         kafkaMetricsReporter = kafkaMetricsReporter
+    )
+
+    val activityHealthService = ActivityHealthService(
+            beskjedTopicActivityService = beskjedTopicActivityService,
+            oppgaveTopicActivityService = oppgaveTopicActivityService,
+            innboksTopicActivityService = innboksTopicActivityService,
+            doneTopicActivityService = doneTopicActivityService,
+            statusoppdateringTopicActivityService = statusoppdateringTopicActivityService,
+            lowActivityStreakThreshold = environment.lowActivityStreakThreshold,
+            moderateActivityStreakThreshold = environment.moderateActivityStreakThreshold,
+            highActivityStreakThreshold = environment.highActivityStreakThreshold
     )
 
     var periodicMetricsSubmitter = initializePeriodicMetricsSubmitter()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
@@ -37,7 +37,7 @@ data class Environment(val bootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP
                        val monitorOnPremOppgaveActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_OPPGAVE_ACTIVITY"),
                        val monitorOnPremInnboksActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_INNBOKS_ACTIVITY"),
                        val monitorOnPremDoneActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_DONE_ACTIVITY"),
-                       val monitorOnPremStatusOppdateringActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_STATUSOPPDATERING_ACTIVITY")
+                       val monitorOnPremStatusoppdateringActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_STATUSOPPDATERING_ACTIVITY")
 )
 
 fun isOtherEnvironmentThanProd() = System.getenv("NAIS_CLUSTER_NAME") != "prod-sbs"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
@@ -29,7 +29,10 @@ data class Environment(val bootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP
                        val aivenSchemaRegistry: String = getEnvVar("KAFKA_SCHEMA_REGISTRY"),
                        val aivenSchemaRegistryUser: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
                        val aivenSchemaRegistryPassword: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
-                       val requireEventsInFirstBatch : Boolean = getEnvVarAsBoolean("REQUIRE_EVENTS_IN_FIRST_BATCH", false)
+                       val activityHistoryLength: Int = getEnvVarAsInt("ACTIVITY_HISTORY_LENGTH", 30),
+                       val lowActivityStreakThreshold: Int = getEnvVarAsInt("LOW_ACTIVITY_STREAK_THRESHOLD", 30),
+                       val moderateActivityStreakThreshold: Int = getEnvVarAsInt("MODERATE_ACTIVITY_STREAK_THRESHOLD", 15),
+                       val highActivityStreakThreshold: Int = getEnvVarAsInt("HIGH_ACTIVITY_STREAK_THRESHOLD", 5)
 )
 
 fun isOtherEnvironmentThanProd() = System.getenv("NAIS_CLUSTER_NAME") != "prod-sbs"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/Environment.kt
@@ -30,9 +30,14 @@ data class Environment(val bootstrapServers: String = getEnvVar("KAFKA_BOOTSTRAP
                        val aivenSchemaRegistryUser: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
                        val aivenSchemaRegistryPassword: String = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
                        val activityHistoryLength: Int = getEnvVarAsInt("ACTIVITY_HISTORY_LENGTH", 30),
-                       val lowActivityStreakThreshold: Int = getEnvVarAsInt("LOW_ACTIVITY_STREAK_THRESHOLD", 30),
+                       val lowActivityStreakThreshold: Int = getEnvVarAsInt("LOW_ACTIVITY_STREAK_THRESHOLD", 60),
                        val moderateActivityStreakThreshold: Int = getEnvVarAsInt("MODERATE_ACTIVITY_STREAK_THRESHOLD", 15),
-                       val highActivityStreakThreshold: Int = getEnvVarAsInt("HIGH_ACTIVITY_STREAK_THRESHOLD", 5)
+                       val highActivityStreakThreshold: Int = getEnvVarAsInt("HIGH_ACTIVITY_STREAK_THRESHOLD", 5),
+                       val monitorOnPremBeskjedActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_BESKJED_ACTIVITY"),
+                       val monitorOnPremOppgaveActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_OPPGAVE_ACTIVITY"),
+                       val monitorOnPremInnboksActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_INNBOKS_ACTIVITY"),
+                       val monitorOnPremDoneActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_DONE_ACTIVITY"),
+                       val monitorOnPremStatusOppdateringActivity: Boolean = getEnvVarAsBoolean("MONITOR_ON_PREM_STATUSOPPDATERING_ACTIVITY")
 )
 
 fun isOtherEnvironmentThanProd() = System.getenv("NAIS_CLUSTER_NAME") != "prod-sbs"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/bootstrap.kt
@@ -16,7 +16,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     DefaultExports.initialize()
     install(DefaultHeaders)
     routing {
-        healthApi(appContext.healthService)
+        healthApi(appContext.healthService, appContext.activityHealthService)
         metricsSubmitterApi(appContext)
         consumerApi(appContext)
     }
@@ -25,7 +25,6 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     configureShutdownHook(appContext)
 
     log.info("Delta counting enabled: ${appContext.environment.deltaCountingEnabled}")
-    log.info("Require events in first batch enabled: ${appContext.environment.requireEventsInFirstBatch}")
 }
 
 private fun Application.configureStartupHook(appContext: ApplicationContext) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthService.kt
@@ -11,9 +11,7 @@ class ActivityHealthService(
         val innboksTopicActivityService: TopicActivityService,
         val doneTopicActivityService: TopicActivityService,
         val statusoppdateringTopicActivityService: TopicActivityService,
-        val lowActivityStreakThreshold: Int,
-        val moderateActivityStreakThreshold: Int,
-        val highActivityStreakThreshold: Int
+        val config: ActivityHealthServiceConfig
 ) {
 
     private val log = LoggerFactory.getLogger(ActivityHealthService::class.java)
@@ -21,23 +19,23 @@ class ActivityHealthService(
     fun assertOnPremTopicActivityHealth(): Boolean {
         var healthy = true
 
-        if (!assertServiceHealth(beskjedTopicActivityService, "on-prem beskjed")) {
+        if (config.monitorOnPremBeskjedActivity && !assertServiceHealth(beskjedTopicActivityService, "on-prem beskjed")) {
             healthy = false
         }
 
-        if (!assertServiceHealth(oppgaveTopicActivityService, "on-prem oppgave")) {
+        if (config.monitorOnPremOppgaveActivity && !assertServiceHealth(oppgaveTopicActivityService, "on-prem oppgave")) {
             healthy = false
         }
 
-        if (!assertServiceHealth(innboksTopicActivityService, "on-prem innboks")) {
+        if (config.monitorOnPremInnboksActivity && !assertServiceHealth(innboksTopicActivityService, "on-prem innboks")) {
             healthy = false
         }
 
-        if (!assertServiceHealth(doneTopicActivityService, "on-prem done")) {
+        if (config.monitorOnPremDoneActivity && !assertServiceHealth(doneTopicActivityService, "on-prem done")) {
             healthy = false
         }
 
-        if (!assertServiceHealth(statusoppdateringTopicActivityService, "on-prem statusoppdatering")) {
+        if (config.monitorOnPremStatusOppdateringActivity && !assertServiceHealth(statusoppdateringTopicActivityService, "on-prem statusoppdatering")) {
             healthy = false
         }
 
@@ -57,9 +55,20 @@ class ActivityHealthService(
 
     private fun stateIsHealthy(state: ActivityState): Boolean {
         return when(state.recentActivityLevel) {
-            ActivityLevel.LOW -> state.inactivityStreak < lowActivityStreakThreshold
-            ActivityLevel.MODERATE -> state.inactivityStreak < moderateActivityStreakThreshold
-            ActivityLevel.HIGH -> state.inactivityStreak < highActivityStreakThreshold
+            ActivityLevel.LOW -> state.inactivityStreak < config.lowActivityStreakThreshold
+            ActivityLevel.MODERATE -> state.inactivityStreak < config.moderateActivityStreakThreshold
+            ActivityLevel.HIGH -> state.inactivityStreak < config.highActivityStreakThreshold
         }
     }
 }
+
+data class ActivityHealthServiceConfig(
+        val lowActivityStreakThreshold: Int,
+        val moderateActivityStreakThreshold: Int,
+        val highActivityStreakThreshold: Int,
+        val monitorOnPremBeskjedActivity: Boolean,
+        val monitorOnPremOppgaveActivity: Boolean,
+        val monitorOnPremInnboksActivity: Boolean,
+        val monitorOnPremDoneActivity: Boolean,
+        val monitorOnPremStatusOppdateringActivity: Boolean
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthService.kt
@@ -1,0 +1,65 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.health
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityLevel
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityState
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
+import org.slf4j.LoggerFactory
+
+class ActivityHealthService(
+        val beskjedTopicActivityService: TopicActivityService,
+        val oppgaveTopicActivityService: TopicActivityService,
+        val innboksTopicActivityService: TopicActivityService,
+        val doneTopicActivityService: TopicActivityService,
+        val statusoppdateringTopicActivityService: TopicActivityService,
+        val lowActivityStreakThreshold: Int,
+        val moderateActivityStreakThreshold: Int,
+        val highActivityStreakThreshold: Int
+) {
+
+    private val log = LoggerFactory.getLogger(ActivityHealthService::class.java)
+
+    fun assertOnPremTopicActivityHealth(): Boolean {
+        var healthy = true
+
+        if (!assertServiceHealth(beskjedTopicActivityService, "on-prem beskjed")) {
+            healthy = false
+        }
+
+        if (!assertServiceHealth(oppgaveTopicActivityService, "on-prem oppgave")) {
+            healthy = false
+        }
+
+        if (!assertServiceHealth(innboksTopicActivityService, "on-prem innboks")) {
+            healthy = false
+        }
+
+        if (!assertServiceHealth(doneTopicActivityService, "on-prem done")) {
+            healthy = false
+        }
+
+        if (!assertServiceHealth(statusoppdateringTopicActivityService, "on-prem statusoppdatering")) {
+            healthy = false
+        }
+
+        return healthy
+    }
+
+    private fun assertServiceHealth(service: TopicActivityService, topicSource: String): Boolean {
+        val state = service.getActivityState()
+
+        return if (stateIsHealthy(state)) {
+            true
+        } else {
+            log.warn("On-prem topic counting for $topicSource looks unhealthy. Recent activity is ${state.recentActivityLevel} and counted zero events ${state.inactivityStreak} times in a row.")
+            false
+        }
+    }
+
+    private fun stateIsHealthy(state: ActivityState): Boolean {
+        return when(state.recentActivityLevel) {
+            ActivityLevel.LOW -> state.inactivityStreak < lowActivityStreakThreshold
+            ActivityLevel.MODERATE -> state.inactivityStreak < moderateActivityStreakThreshold
+            ActivityLevel.HIGH -> state.inactivityStreak < highActivityStreakThreshold
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/HealthService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/HealthService.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.health
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.ApplicationContext
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
 
 class HealthService(private val applicationContext: ApplicationContext) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/healthApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/healthApi.kt
@@ -12,14 +12,12 @@ import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
 import java.time.Instant
 
-fun Routing.healthApi(healthService: HealthService) {
+fun Routing.healthApi(healthService: HealthService, activityHealthService: ActivityHealthService) {
 
     val start = Instant.now()
 
     get("/internal/isAlive") {
-        val timeSinceStart = Instant.now().epochSecond - start.epochSecond
-
-        if (timeSinceStart < 600) {
+        if (activityHealthService.assertOnPremTopicActivityHealth()) {
             call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
         } else {
             call.respondText(text = "DEAD", status = InternalServerError, contentType = ContentType.Text.Plain)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/healthApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/healthApi.kt
@@ -14,8 +14,6 @@ import java.time.Instant
 
 fun Routing.healthApi(healthService: HealthService, activityHealthService: ActivityHealthService) {
 
-    val start = Instant.now()
-
     get("/internal/isAlive") {
         if (activityHealthService.assertOnPremTopicActivityHealth()) {
             call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/healthApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/healthApi.kt
@@ -1,19 +1,29 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.health
 
-import io.ktor.application.call
+import io.ktor.application.*
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.response.respondText
 import io.ktor.response.respondTextWriter
 import io.ktor.routing.Routing
 import io.ktor.routing.get
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
+import java.time.Instant
 
 fun Routing.healthApi(healthService: HealthService) {
 
+    val start = Instant.now()
+
     get("/internal/isAlive") {
-        call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+        val timeSinceStart = Instant.now().epochSecond - start.epochSecond
+
+        if (timeSinceStart < 600) {
+            call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+        } else {
+            call.respondText(text = "DEAD", status = InternalServerError, contentType = ContentType.Text.Plain)
+        }
     }
 
     get("/internal/isReady") {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounter.kt
@@ -45,7 +45,6 @@ class TopicEventTypeCounter<K>(
     }
 
     private fun pollAndCountEvents(eventType: EventType): TopicMetricsSession {
-        topicActivityService.reportEventsFound()
 
         val startTime = Instant.now()
 
@@ -54,9 +53,12 @@ class TopicEventTypeCounter<K>(
         var records = consumer.kafkaConsumer.poll(timeoutConfig.pollingTimeout)
 
         if (records.foundRecords()) {
+            topicActivityService.reportEventsFound()
+
             countBatch(records, session)
 
             while (records.foundRecords() && !maxTimeoutExceeded(startTime, timeoutConfig)) {
+
                 records = consumer.kafkaConsumer.poll(timeoutConfig.pollingTimeout)
                 countBatch(records, session)
             }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounter.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventTypeCounter.kt
@@ -9,6 +9,7 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.Consum
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.foundRecords
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.resetTheGroupIdsOffsetToZero
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.slf4j.LoggerFactory
@@ -17,9 +18,9 @@ import java.time.Instant
 
 class TopicEventTypeCounter<K>(
         val consumer: Consumer<K, GenericRecord>,
+        val topicActivityService: TopicActivityService,
         val eventType: EventType,
-        val deltaCountingEnabled: Boolean,
-        val requireEventsInFirstBatch : Boolean = false
+        val deltaCountingEnabled: Boolean
 ) {
 
     private val log = LoggerFactory.getLogger(TopicEventTypeCounter::class.java)
@@ -44,6 +45,8 @@ class TopicEventTypeCounter<K>(
     }
 
     private fun pollAndCountEvents(eventType: EventType): TopicMetricsSession {
+        topicActivityService.reportEventsFound()
+
         val startTime = Instant.now()
 
         val session = previousSession?.let { TopicMetricsSession(it) } ?: TopicMetricsSession(eventType)
@@ -65,23 +68,12 @@ class TopicEventTypeCounter<K>(
             }
 
         } else {
-            log.info("Ingen eventer funnet ved første polling etter $eventType, dette kan indikerer at noe er feil.")
-            if(shouldCountAllEventsOnTopicInNextPoll()) {
-                resetCountingSession()
-            }
+            topicActivityService.reportNoEventsFound()
         }
 
         session.calculateProcessingTime()
 
         return session
-    }
-
-    private fun shouldCountAllEventsOnTopicInNextPoll() = deltaCountingEnabled && requireEventsInFirstBatch
-
-    private fun resetCountingSession() {
-        log.info("Resetter tellesesjonen for $eventType, og teller alle eventer i neste runde.")
-        previousSession = null
-        consumer.kafkaConsumer.resetTheGroupIdsOffsetToZero()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityLevel.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityLevel.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity
+
+enum class ActivityLevel {
+    HIGH, MODERATE, LOW
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityState.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityState.kt
@@ -2,6 +2,5 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 data class ActivityState(
         val recentActivityLevel: ActivityLevel,
-        val activityPercentage: Int,
         val inactivityStreak: Int
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityState.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityState.kt
@@ -1,0 +1,7 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity
+
+data class ActivityState(
+        val recentActivityLevel: ActivityLevel,
+        val activityPercentage: Int,
+        val inactivityStreak: Int
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTracker.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity
 
-class ActivityTracker(private val historyLength: Int) {
+class ActivityTracker(historyLength: Int) {
     private val recentCountHistory = FixedLengthBooleanQueue(historyLength)
 
     private var inactivityStreak = 0

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTracker.kt
@@ -1,0 +1,55 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity
+
+class ActivityTracker(private val historyLength: Int) {
+    private val recentCountHistory = FixedSizeBooleanQueue(historyLength)
+
+    private var inactivityStreak = 0
+
+    fun eventsFound() {
+        inactivityStreak = 0
+        recentCountHistory.add(true)
+    }
+
+    fun noEventsFound() {
+        inactivityStreak++
+        recentCountHistory.add(false)
+    }
+
+    fun getLevelOfRecentActivity(): ActivityLevel {
+        val percentage = getActivityPercentage()
+        return when {
+            percentage < 25 -> ActivityLevel.LOW
+            percentage > 75 -> ActivityLevel.HIGH
+            else -> ActivityLevel.MODERATE
+        }
+    }
+
+    fun getActivityPercentage(): Int {
+        val percentage = (recentCountHistory.countTrueEntries() * 100.0) / historyLength
+
+        return (percentage + 0.5).toInt()
+    }
+
+    fun getInactivityStreak(): Int = inactivityStreak
+}
+
+private class FixedSizeBooleanQueue(private val size: Int) {
+    private var entries: Int = 0
+
+    private var cursor: Int = 0
+
+    private val array = BooleanArray(size) { true }
+
+    fun add(entry: Boolean) {
+        array[cursor] = entry
+
+        entries++
+        cursor = (cursor + 1) % size
+    }
+
+    fun countTrueEntries(): Int {
+        return array.sumBy { entry ->
+            if (entry) 1 else 0
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTracker.kt
@@ -34,8 +34,6 @@ class ActivityTracker(private val historyLength: Int) {
 }
 
 private class FixedSizeBooleanQueue(private val size: Int) {
-    private var entries: Int = 0
-
     private var cursor: Int = 0
 
     private val array = BooleanArray(size) { true }
@@ -43,7 +41,6 @@ private class FixedSizeBooleanQueue(private val size: Int) {
     fun add(entry: Boolean) {
         array[cursor] = entry
 
-        entries++
         cursor = (cursor + 1) % size
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/TopicActivityService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/TopicActivityService.kt
@@ -1,0 +1,21 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity
+
+class TopicActivityService(historyLength: Int) {
+    private val activityCounter = ActivityTracker(historyLength)
+
+    fun reportEventsFound() {
+        activityCounter.eventsFound()
+    }
+
+    fun reportNoEventsFound() {
+        activityCounter.noEventsFound()
+    }
+
+    fun getActivityState(): ActivityState {
+        return ActivityState(
+                activityCounter.getLevelOfRecentActivity(),
+                activityCounter.getActivityPercentage(),
+                activityCounter.getInactivityStreak()
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/TopicActivityService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/TopicActivityService.kt
@@ -14,7 +14,6 @@ class TopicActivityService(historyLength: Int) {
     fun getActivityState(): ActivityState {
         return ActivityState(
                 activityCounter.getLevelOfRecentActivity(),
-                activityCounter.getActivityPercentage(),
                 activityCounter.getInactivityStreak()
         )
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/EnvironmentTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/EnvironmentTest.kt
@@ -25,7 +25,12 @@ internal class EnvironmentTest {
         "KAFKA_CREDSTORE_PASSWORD" to "kafka_credstore_password",
         "KAFKA_SCHEMA_REGISTRY" to "kafka_schema_registry",
         "KAFKA_SCHEMA_REGISTRY_USER" to "kafka_schema_registry_user",
-        "KAFKA_SCHEMA_REGISTRY_PASSWORD" to "kafka_shchema_registry_password"
+        "KAFKA_SCHEMA_REGISTRY_PASSWORD" to "kafka_shchema_registry_password",
+        "MONITOR_ON_PREM_BESKJED_ACTIVITY" to "true",
+        "MONITOR_ON_PREM_OPPGAVE_ACTIVITY" to "true",
+        "MONITOR_ON_PREM_INNBOKS_ACTIVITY" to "true",
+        "MONITOR_ON_PREM_DONE_ACTIVITY" to "true",
+        "MONITOR_ON_PREM_STATUSOPPDATERING_ACTIVITY" to "true"
     )
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthDeciderTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthDeciderTest.kt
@@ -1,0 +1,72 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.health
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityLevel
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityLevel.*
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityState
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class ActivityHealthDeciderTest {
+    private val lowActivityThreshold = 100
+    private val moderateActivityThreshold = 50
+    private val highActivityThreshHold = 10
+
+    private val decider = ActivityHealthDecider(
+            lowActivityThreshold,
+            moderateActivityThreshold,
+            highActivityThreshHold
+    )
+
+    @Test
+    fun `A sufficiently low inactivity streak should never be considered unhealthy`() {
+        val streak = highActivityThreshHold - 5
+
+        val lowState = ActivityState(LOW, streak)
+        val moderateState = ActivityState(MODERATE, streak)
+        val highState = ActivityState(HIGH, streak)
+
+        decider.stateIsHealthy(lowState) `should be equal to` true
+        decider.stateIsHealthy(moderateState) `should be equal to` true
+        decider.stateIsHealthy(highState) `should be equal to` true
+    }
+
+    @Test
+    fun `A sufficiently high inactivity streak should always be considered unhealthy`() {
+        val streak = lowActivityThreshold + 5
+
+        val lowState = ActivityState(LOW, streak)
+        val moderateState = ActivityState(MODERATE, streak)
+        val highState = ActivityState(HIGH, streak)
+
+        decider.stateIsHealthy(lowState) `should be equal to` false
+        decider.stateIsHealthy(moderateState) `should be equal to` false
+        decider.stateIsHealthy(highState) `should be equal to` false
+    }
+
+    @Test
+    fun `A streak just below the moderate threshold should only be considered unhealthy if activity is high`() {
+        val streak = moderateActivityThreshold - 5
+
+        val lowState = ActivityState(LOW, streak)
+        val moderateState = ActivityState(MODERATE, streak)
+        val highState = ActivityState(HIGH, streak)
+
+        decider.stateIsHealthy(lowState) `should be equal to` true
+        decider.stateIsHealthy(moderateState) `should be equal to` true
+        decider.stateIsHealthy(highState) `should be equal to` false
+    }
+
+    @Test
+    fun `A streak just above the moderate threshold should only be considered healthy if activity is low`() {
+        val streak = moderateActivityThreshold + 5
+
+        val lowState = ActivityState(LOW, streak)
+        val moderateState = ActivityState(MODERATE, streak)
+        val highState = ActivityState(HIGH, streak)
+
+        decider.stateIsHealthy(lowState) `should be equal to` true
+        decider.stateIsHealthy(moderateState) `should be equal to` false
+        decider.stateIsHealthy(highState) `should be equal to` false
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/health/ActivityHealthServiceTest.kt
@@ -1,0 +1,105 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.health
+
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityLevel
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.ActivityState
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+internal class ActivityHealthServiceTest {
+
+    private val beskjedTopicActivityService: TopicActivityService = mockk()
+    private val oppgaveTopicActivityService: TopicActivityService = mockk()
+    private val innboksTopicActivityService: TopicActivityService = mockk()
+    private val doneTopicActivityService: TopicActivityService = mockk()
+    private val statusoppdateringTopicActivityService: TopicActivityService = mockk()
+
+    private val decider: ActivityHealthDecider = mockk()
+    private val config: ActivityMonitoringToggles = mockk()
+
+    private val activityHealthService = ActivityHealthService(
+            beskjedTopicActivityService,
+            oppgaveTopicActivityService,
+            innboksTopicActivityService,
+            doneTopicActivityService,
+            statusoppdateringTopicActivityService,
+            decider,
+            config
+    )
+
+    @AfterEach
+    fun cleanUp() {
+        clearMocks(beskjedTopicActivityService)
+        clearMocks(oppgaveTopicActivityService)
+        clearMocks(innboksTopicActivityService)
+        clearMocks(doneTopicActivityService)
+        clearMocks(statusoppdateringTopicActivityService)
+        clearMocks(config)
+    }
+
+    @Test
+    fun `Should only monitor specific topic activity if requested`() {
+        every { config.monitorOnPremBeskjedActivity } returns true
+        every { config.monitorOnPremOppgaveActivity } returns true
+        every { config.monitorOnPremInnboksActivity } returns false
+        every { config.monitorOnPremDoneActivity } returns false
+        every { config.monitorOnPremStatusoppdateringActivity } returns false
+
+        val healthyActivity = ActivityState(ActivityLevel.HIGH, 0)
+
+        every { decider.stateIsHealthy(healthyActivity) } returns true
+
+        every { beskjedTopicActivityService.getActivityState() } returns healthyActivity
+        every { oppgaveTopicActivityService.getActivityState() } returns healthyActivity
+
+
+        val result = activityHealthService.assertOnPremTopicActivityHealth()
+
+        verify(exactly = 1) { beskjedTopicActivityService.getActivityState() }
+        verify(exactly = 1) { oppgaveTopicActivityService.getActivityState() }
+        verify(exactly = 0) { innboksTopicActivityService.getActivityState() }
+        verify(exactly = 0) { doneTopicActivityService.getActivityState() }
+        verify(exactly = 0) { statusoppdateringTopicActivityService.getActivityState() }
+
+        result `should be equal to` true
+    }
+
+    @Test
+    fun `Should report unhealthy if any one service reports being unhealthy`() {
+        every { config.monitorOnPremBeskjedActivity } returns true
+        every { config.monitorOnPremOppgaveActivity } returns true
+        every { config.monitorOnPremInnboksActivity } returns true
+        every { config.monitorOnPremDoneActivity } returns true
+        every { config.monitorOnPremStatusoppdateringActivity } returns true
+
+        val threshold = 10
+
+        val healthyActivity = ActivityState(ActivityLevel.HIGH, 0)
+        val unhealthyActivity = ActivityState(ActivityLevel.HIGH, threshold + 1)
+
+        every { decider.stateIsHealthy(healthyActivity) } returns true
+        every { decider.stateIsHealthy(unhealthyActivity) } returns false
+
+        every { beskjedTopicActivityService.getActivityState() } returns healthyActivity
+        every { oppgaveTopicActivityService.getActivityState() } returns healthyActivity
+        every { innboksTopicActivityService.getActivityState() } returns unhealthyActivity
+        every { doneTopicActivityService.getActivityState() } returns healthyActivity
+        every { statusoppdateringTopicActivityService.getActivityState() } returns healthyActivity
+
+
+        val result = activityHealthService.assertOnPremTopicActivityHealth()
+
+        verify(exactly = 1) { beskjedTopicActivityService.getActivityState() }
+        verify(exactly = 1) { oppgaveTopicActivityService.getActivityState() }
+        verify(exactly = 1) { innboksTopicActivityService.getActivityState() }
+        verify(exactly = 1) { doneTopicActivityService.getActivityState() }
+        verify(exactly = 1) { statusoppdateringTopicActivityService.getActivityState() }
+
+        result `should be equal to` false
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.`with messag
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.exceptions.CountException
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.common.kafka.Consumer
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity.TopicActivityService
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.invoking
 import org.apache.avro.generic.GenericRecord
@@ -29,17 +30,28 @@ internal class TopicEventCounterServiceTest {
     private val doneCountConsumer: Consumer<Nokkel, GenericRecord> = mockk(relaxed = true)
     private val doneInternCountConsumer: Consumer<NokkelIntern, GenericRecord> = mockk(relaxed = true)
     private val feilresponsCountConsumer: Consumer<NokkelFeilrespons, GenericRecord> = mockk(relaxed = true)
-    private val beskjedCounter = TopicEventTypeCounter(beskjedCountConsumer, EventType.BESKJED, false)
-    private val beskjedInternCounter = TopicEventTypeCounter(beskjedInternCountConsumer, EventType.BESKJED_INTERN, false)
-    private val innboksCounter = TopicEventTypeCounter(innboksCountConsumer, EventType.INNBOKS, false)
-    private val innboksInternCounter = TopicEventTypeCounter(innboksInternCountConsumer, EventType.INNBOKS_INTERN, false)
-    private val oppgaveCounter = TopicEventTypeCounter(oppgaveCountConsumer, EventType.OPPGAVE, false)
-    private val oppgaveInternCounter = TopicEventTypeCounter(oppgaveInternCountConsumer, EventType.OPPGAVE_INTERN, false)
-    private val statusoppdateringCounter = TopicEventTypeCounter(statusoppdateringCountConsumer, EventType.STATUSOPPDATERING, false)
-    private val statusoppdateringInternCounter = TopicEventTypeCounter(statusoppdateringInternCountConsumer, EventType.STATUSOPPDATERING_INTERN, false)
-    private val doneCounter = TopicEventTypeCounter(doneCountConsumer, EventType.DONE, false)
-    private val doneInternCounter = TopicEventTypeCounter(doneInternCountConsumer, EventType.DONE_INTERN, false)
-    private val feilresponsCounter = TopicEventTypeCounter(feilresponsCountConsumer, EventType.FEILRESPONS, false)
+    private val beskjedActivityService: TopicActivityService = mockk()
+    private val beskjedInternActivityService: TopicActivityService = mockk()
+    private val innboksActivityService: TopicActivityService = mockk()
+    private val innboksInternActivityService: TopicActivityService = mockk()
+    private val oppgaveActivityService: TopicActivityService = mockk()
+    private val oppgaveInternActivityService: TopicActivityService = mockk()
+    private val statusoppdateringActivityService: TopicActivityService = mockk()
+    private val statusoppdateringInternActivityService: TopicActivityService = mockk()
+    private val doneActivityService: TopicActivityService = mockk()
+    private val doneInternActivityService: TopicActivityService = mockk()
+    private val feilresponsActivityService: TopicActivityService = mockk()
+    private val beskjedCounter = TopicEventTypeCounter(beskjedCountConsumer, beskjedActivityService, EventType.BESKJED, false)
+    private val beskjedInternCounter = TopicEventTypeCounter(beskjedInternCountConsumer, beskjedInternActivityService, EventType.BESKJED_INTERN, false)
+    private val innboksCounter = TopicEventTypeCounter(innboksCountConsumer, innboksActivityService, EventType.INNBOKS, false)
+    private val innboksInternCounter = TopicEventTypeCounter(innboksInternCountConsumer, innboksInternActivityService, EventType.INNBOKS_INTERN, false)
+    private val oppgaveCounter = TopicEventTypeCounter(oppgaveCountConsumer, oppgaveActivityService, EventType.OPPGAVE, false)
+    private val oppgaveInternCounter = TopicEventTypeCounter(oppgaveInternCountConsumer, oppgaveInternActivityService, EventType.OPPGAVE_INTERN, false)
+    private val statusoppdateringCounter = TopicEventTypeCounter(statusoppdateringCountConsumer, statusoppdateringActivityService, EventType.STATUSOPPDATERING, false)
+    private val statusoppdateringInternCounter = TopicEventTypeCounter(statusoppdateringInternCountConsumer, statusoppdateringInternActivityService, EventType.STATUSOPPDATERING_INTERN, false)
+    private val doneCounter = TopicEventTypeCounter(doneCountConsumer, doneActivityService, EventType.DONE, false)
+    private val doneInternCounter = TopicEventTypeCounter(doneInternCountConsumer, doneInternActivityService, EventType.DONE_INTERN, false)
+    private val feilresponsCounter = TopicEventTypeCounter(feilresponsCountConsumer, feilresponsActivityService, EventType.FEILRESPONS, false)
 
     @Test
     internal fun `Should handle exceptions and rethrow as internal exception`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTrackerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/activity/ActivityTrackerTest.kt
@@ -1,0 +1,92 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.activity
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class ActivityTrackerTest {
+
+    @Test
+    fun `Finding events less than 25 percent of the time should be considered low activity`() {
+        val activityTracker = ActivityTracker(historyLength = 20)
+
+        activityTracker.eventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+
+        activityTracker.getLevelOfRecentActivity() `should be equal to` ActivityLevel.LOW
+    }
+
+    @Test
+    fun `Finding events between 25 and 75 percent of the time should be considered moderate activity`() {
+        val activityTracker = ActivityTracker(historyLength = 20)
+
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+
+        activityTracker.getLevelOfRecentActivity() `should be equal to` ActivityLevel.MODERATE
+    }
+
+    @Test
+    fun `Finding events more than 75 percent of the time should be considered high activity`() {
+        val activityTracker = ActivityTracker(historyLength = 20)
+
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.noEventsFound()
+
+        activityTracker.getLevelOfRecentActivity() `should be equal to` ActivityLevel.HIGH
+    }
+
+    @Test
+    fun `Events older than historyLength should not affect level of recent activity`() {
+        val activityTracker = ActivityTracker(historyLength = 5)
+
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+        activityTracker.eventsFound()
+
+        activityTracker.eventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+
+        activityTracker.getLevelOfRecentActivity() `should be equal to` ActivityLevel.LOW
+    }
+
+    @Test
+    fun `Should track noEventsFound streak past historyLength`() {
+        val activityTracker = ActivityTracker(historyLength = 5)
+
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+        activityTracker.noEventsFound()
+
+        activityTracker.getLevelOfRecentActivity() `should be equal to` ActivityLevel.LOW
+        activityTracker.getInactivityStreak() `should be equal to` 10
+    }
+
+    @Test
+    fun `Should report low activity if no events have been recorded yet`() {
+        val activityTracker = ActivityTracker(historyLength = 20)
+
+        activityTracker.getLevelOfRecentActivity() `should be equal to` ActivityLevel.LOW
+    }
+}


### PR DESCRIPTION
La til helsesjekk på topic-tellere. Dersom aktivitet på en gitt topic virker 'unhealthy', vil appen restartes. 

Hva som er 'unhealthy' aktivitet og ikke er basert på hvor mange ganger på rad vi har telt 0 eventer, sett mot generelt aktivitetsnivå. Per nå er aktivitet målt over den siste halvtimen (historikklengde = 30 og 1 polling per minutt). Aktivitetsnivå er definert på følgende måte:

Hvis vi har funnet eventer under 25% av gangene vi har forsøkt å polle -> lavt
Hvis vi har funnet eventer mellom 25% og 75% av gangene vi har forsøkt å polle -> moderat
Hvis vi har funnet eventer over 75% av gangene vi har forsøkt å polle -> høyt

Default grenser for hvor mange ganger vi kan vi kan polle 0 eventer på rad er som følger:

Hvis aktivitetsnivå er høyt, kan vi kun telle 0 eventer 5 ganger på rad før appen restartes.
Hvis aktivitetsnivå er moderat, kan vi telle 0 eventer 15 ganger på rad.
Hvis aktivitetsnivå er lavt, kan vi kun telle 0 eventer 60 ganger på rad.

Grunnen til at det er gjort slik er at appen kan reagere kjapt på feil state midt på dagen, når aktiviteten er høy og vi alltid forventer å telle nye eventer, uten at appen restartes konstant ved nattetid. 