### PR TITLE
Øker minnemengden til det dobbelte av den opprinnelige verdien.

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -35,9 +35,9 @@ spec:
   resources:
     limits:
       cpu: "3"
-      memory: 3000Mi
+      memory: 4800Mi
     requests:
       cpu: "1"
-      memory: 2560Mi
+      memory: 4096Mi
   kafka:
     pool: {{kafkapool}}


### PR DESCRIPTION
Den opprinnelige verdien var 2400Mi, som ble øket med 25% i desember. Dette økes nå med 100%.

Dette gjøres fordi appen nå må prosessere vesentlig flere eventer enn tidligere, nærmere 20 mill vs 8-9 mill ved forrige minnejustering.