### PR TITLE
Nytt forsøk på å aktivere innbokstelling

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/KafkaConsumerSetup.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/config/KafkaConsumerSetup.kt
@@ -19,11 +19,11 @@ object KafkaConsumerSetup {
         appContext.beskjedCountOnPremConsumer.startSubscription()
         appContext.oppgaveCountOnPremConsumer.startSubscription()
         appContext.doneCountOnPremConsumer.startSubscription()
+        appContext.innboksCountOnPremConsumer.startSubscription()
         if (isOtherEnvironmentThanProd()) {
-            appContext.innboksCountOnPremConsumer.startSubscription()
             appContext.statusoppdateringCountOnPremConsumer.startSubscription()
         } else {
-            log.info("Er i produksjonsmiljø, unnlater å starte innboks- og statusoppdateringconsumer on prem.")
+            log.info("Er i produksjonsmiljø, unnlater å starte statusoppdateringconsumer on prem.")
         }
     }
 
@@ -43,8 +43,8 @@ object KafkaConsumerSetup {
         appContext.beskjedCountOnPremConsumer.stop()
         appContext.oppgaveCountOnPremConsumer.stop()
         appContext.doneCountOnPremConsumer.stop()
+        appContext.innboksCountOnPremConsumer.stop()
         if (isOtherEnvironmentThanProd()) {
-            appContext.innboksCountOnPremConsumer.stop()
             appContext.statusoppdateringCountOnPremConsumer.stop()
         }
         log.info("...ferdig med å stoppe kafka-pollerne on prem.")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbEventCounterOnPremService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/db/count/DbEventCounterOnPremService.kt
@@ -58,18 +58,13 @@ class DbEventCounterOnPremService(
 
     suspend fun countInnboksEventer(): DbCountingMetricsSession {
         val eventType = EventType.INNBOKS
-        return if (isOtherEnvironmentThanProd()) {
-            try {
-                metricsProbe.runWithMetrics(eventType) {
-                    val grupperPerProdusent = repository.getNumberOfEventsOfTypeGroupedByProdusent(EventType.INNBOKS)
-                    addEventsByProducer(grupperPerProdusent)
-                }
-
-            } catch (e: Exception) {
-                throw CountException("Klarte ikke å telle antall innboks-eventer i cache-en", e)
+        return try {
+            metricsProbe.runWithMetrics(eventType) {
+                val grupperPerProdusent = repository.getNumberOfEventsOfTypeGroupedByProdusent(EventType.INNBOKS)
+                addEventsByProducer(grupperPerProdusent)
             }
-        } else {
-            DbCountingMetricsSession(eventType)
+        } catch (e: Exception) {
+            throw CountException("Klarte ikke å telle antall innboks-eventer i cache-en", e)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterAivenService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterAivenService.kt
@@ -29,6 +29,12 @@ class TopicEventCounterAivenService<K>(
                 async { TopicMetricsSession(EventType.OPPGAVE_INTERN) }
             }
 
+            val innboks = if(isOtherEnvironmentThanProd()) {
+                innboksCounter.countEventsAsync()
+            } else {
+                async { TopicMetricsSession(EventType.INNBOKS_INTERN) }
+            }
+
             val done = if(isOtherEnvironmentThanProd()) {
                 doneCounter.countEventsAsync()
             } else {
@@ -41,7 +47,6 @@ class TopicEventCounterAivenService<K>(
                 async { TopicMetricsSession(EventType.FEILRESPONS) }
             }
 
-            val innboks = async { TopicMetricsSession(EventType.INNBOKS_INTERN) }
             val statusoppdateringer = async { TopicMetricsSession(EventType.STATUSOPPDATERING_INTERN) }
 
             val sessions = CountingMetricsSessions()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterOnPremService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/TopicEventCounterOnPremService.kt
@@ -19,12 +19,7 @@ class TopicEventCounterOnPremService<K>(
         val beskjeder = beskjedCounter.countEventsAsync()
         val oppgaver = oppgaveCounter.countEventsAsync()
         val done = doneCounter.countEventsAsync()
-
-        val innboks = if (isOtherEnvironmentThanProd()) {
-            innboksCounter.countEventsAsync()
-        } else {
-            async { TopicMetricsSession(EventType.INNBOKS) }
-        }
+        val innboks = innboksCounter.countEventsAsync()
 
         val statusoppdateringer = if(isOtherEnvironmentThanProd()) {
             statusoppdateringCounter.countEventsAsync()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/CountingMetricsSessionsObjectMother.kt
@@ -26,12 +26,12 @@ object CountingMetricsSessionsObjectMother {
         }
     }
 
-    fun giveMeDatabaseSessionsForAllExternalEventTypesExceptForInnboks(): CountingMetricsSessions {
+    fun giveMeDatabaseSessionsForAllExternalEventTypesExceptForStatusoppdatering(): CountingMetricsSessions {
         return CountingMetricsSessions().apply {
             put(EventType.BESKJED, DbCountingMetricsSessionObjectMother.giveMeBeskjedSessionWithOneCountedEvent())
             put(EventType.DONE, DbCountingMetricsSessionObjectMother.giveMeDoneSessionWithTwoCountedEvents())
             put(EventType.OPPGAVE, DbCountingMetricsSessionObjectMother.giveMeOppgaveSessionWithFourCountedEvents())
-            put(EventType.STATUSOPPDATERING, DbCountingMetricsSessionObjectMother.giveMeStatusoppdateringSessionWithFourCountedEvents())
+            put(EventType.INNBOKS, DbCountingMetricsSessionObjectMother.giveMeInnboksSessionWithThreeCountedEvents())
         }
     }
 
@@ -56,12 +56,12 @@ object CountingMetricsSessionsObjectMother {
         }
     }
 
-    fun giveMeTopicSessionsForAllExternalEventTypesExceptForInnboks(): CountingMetricsSessions {
+    fun giveMeTopicSessionsForAllExternalEventTypesExceptForStatusoppdatering(): CountingMetricsSessions {
         return CountingMetricsSessions().apply {
             put(EventType.BESKJED, TopicMetricsSessionObjectMother.giveMeBeskjedSessionWithTwoCountedEvents())
             put(EventType.DONE, TopicMetricsSessionObjectMother.giveMeDoneSessionWithThreeCountedEvent())
             put(EventType.OPPGAVE, TopicMetricsSessionObjectMother.giveMeOppgaveSessionWithFiveCountedEvent())
-            put(EventType.STATUSOPPDATERING, TopicMetricsSessionObjectMother.giveMeStatusoppdateringSessionWithFiveCountedEvent())
+            put(EventType.INNBOKS, TopicMetricsSessionObjectMother.giveMeInnboksSessionWithFourCountedEvent())
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/MetricsSubmitterServiceTest.kt
@@ -6,8 +6,8 @@ import no.nav.brukernotifikasjon.schemas.Nokkel
 import no.nav.brukernotifikasjon.schemas.internal.NokkelIntern
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.config.EventType
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.CountingMetricsSessionsObjectMother
-import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterGCPService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbCountingMetricsSession
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterGCPService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbEventCounterOnPremService
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.db.count.DbMetricsReporter
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.TopicEventCounterAivenService
@@ -75,9 +75,9 @@ internal class MetricsSubmitterServiceTest {
 
     @Test
     fun `Should not report metrics for event types without metrics session`() {
-        val topicMetricsSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypesExceptForInnboks()
+        val topicMetricsSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypesExceptForStatusoppdatering()
         val topicMetricsInternSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllInternalEventTypes()
-        val dbMetricsSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypesExceptForInnboks()
+        val dbMetricsSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypesExceptForStatusoppdatering()
         val dbMetricInternSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllInternalEventTypes()
 
         coEvery { topicEventCounterServiceOnPrem.countAllEventTypesAsync() } returns topicMetricsSessions
@@ -107,15 +107,17 @@ internal class MetricsSubmitterServiceTest {
             submitter.submitMetrics()
         }
 
-        reportedTopicMetricsForEventTypes `should not contain` EventType.INNBOKS
+        reportedTopicMetricsForEventTypes `should contain` EventType.INNBOKS
         reportedTopicMetricsForEventTypes `should contain` EventType.BESKJED
         reportedTopicMetricsForEventTypes `should contain` EventType.DONE
         reportedTopicMetricsForEventTypes `should contain` EventType.OPPGAVE
+        reportedTopicMetricsForEventTypes `should not contain` EventType.STATUSOPPDATERING
 
-        reportedDbMetricsForEventTypes `should not contain` EventType.INNBOKS
+        reportedDbMetricsForEventTypes `should contain` EventType.INNBOKS
         reportedDbMetricsForEventTypes `should contain` EventType.BESKJED
         reportedDbMetricsForEventTypes `should contain` EventType.DONE
         reportedDbMetricsForEventTypes `should contain` EventType.OPPGAVE
+        reportedDbMetricsForEventTypes `should not contain` EventType.STATUSOPPDATERING
     }
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/SessionComparatorTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/submitter/SessionComparatorTest.kt
@@ -8,8 +8,8 @@ internal class SessionComparatorTest {
 
     @Test
     fun `Should return all sessions from both sources, when they have the same session types`() {
-        val allTopicSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypesExceptForInnboks()
-        val allDbSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypesExceptForInnboks()
+        val allTopicSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypesExceptForStatusoppdatering()
+        val allDbSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypesExceptForStatusoppdatering()
 
         val comparator = SessionComparator(allTopicSessions, allDbSessions)
 
@@ -19,7 +19,7 @@ internal class SessionComparatorTest {
 
     @Test
     fun `Should only return sessions present in both sources, if one topic session is missing`() {
-        val oneTopicSessionMissing = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypesExceptForInnboks()
+        val oneTopicSessionMissing = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypesExceptForStatusoppdatering()
         val allDbSessions = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypes()
 
         val comparator = SessionComparator(oneTopicSessionMissing, allDbSessions)
@@ -29,7 +29,7 @@ internal class SessionComparatorTest {
 
     @Test
     fun `Should only return sessions present in both sources, if one database session is missing`() {
-        val oneDbSessionMissing = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypesExceptForInnboks()
+        val oneDbSessionMissing = CountingMetricsSessionsObjectMother.giveMeDatabaseSessionsForAllExternalEventTypesExceptForStatusoppdatering()
         val allTopicSessions = CountingMetricsSessionsObjectMother.giveMeTopicSessionsForAllExternalEventTypes()
 
         val comparator = SessionComparator(allTopicSessions, oneDbSessionMissing)


### PR DESCRIPTION
Det forrige forsøket på dette feilet, fordi konsumeren ikke var satt opp til å faktisk lytte på innboks-topic-en. Det er fikset her i en egen commit. Den andre commit-en er alle endringene fra den forrige PR-en (https://github.com/navikt/dittnav-periodic-metrics-reporter/pull/42).