### PR TITLE
Reduce memory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(Prometheus.common)
     implementation(Prometheus.hotspot)
     implementation(Prometheus.logback)
+    implementation("org.eclipse.collections:eclipse-collections:11.0.0")
 
     testImplementation(H2Database.h2)
     testImplementation(Junit.api)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
@@ -1,20 +1,11 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
 
-interface Fodselsnummer {
-    companion object {
-
-        fun fromString(fodselsnummerString: String): Fodselsnummer {
-            val longValue = fodselsnummerString.toLongOrNull()
-
-            return if (longValue != null) {
-                FodselsnummerNumeric(longValue)
-            } else {
-                FodselsnummerPlainText(fodselsnummerString)
-            }
-        }
-    }
-}
+interface Fodselsnummer
 
 data class FodselsnummerPlainText(val stringValue: String): Fodselsnummer
 
-data class FodselsnummerNumeric(val longValue: Long): Fodselsnummer
+data class FodselsnummerNumeric(val encodedValue: Int): Fodselsnummer
+
+data class FodselsnummerDNummer(val encodedValue: Int): Fodselsnummer
+
+data class FodselsnummerHNummer(val encodedValue: Int): Fodselsnummer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/Fodselsnummer.kt
@@ -5,7 +5,3 @@ interface Fodselsnummer
 data class FodselsnummerPlainText(val stringValue: String): Fodselsnummer
 
 data class FodselsnummerNumeric(val encodedValue: Int): Fodselsnummer
-
-data class FodselsnummerDNummer(val encodedValue: Int): Fodselsnummer
-
-data class FodselsnummerHNummer(val encodedValue: Int): Fodselsnummer

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -2,10 +2,11 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.EventIdParser
+import org.eclipse.collections.impl.set.mutable.UnifiedSet
 
 class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier) {
 
-    private val userEventIds = HashSet<UserEventIdEntry>()
+    private val userEventIds = UnifiedSet<UserEventIdEntry>()
 
     private val eventIdFormatCounter = EventIdFormatCounter()
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/PerProducerTracker.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topi
 
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.UniqueKafkaEventIdentifier
 import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.EventIdParser
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.FodselsnummerParser
 import org.eclipse.collections.impl.set.mutable.UnifiedSet
 
 class PerProducerTracker(initialEntry: UniqueKafkaEventIdentifier) {
@@ -51,16 +52,16 @@ private data class UserEventIdEntry(
 ) {
     companion object {
         fun fromUniqueIdentifier(uniqueIdentifier: UniqueKafkaEventIdentifier): UserEventIdEntry {
-            val fodselsnummer = Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer)
+            val fodselsnummer = FodselsnummerParser.parse(uniqueIdentifier.fodselsnummer)
 
             return if (uniqueIdentifier.fodselsnummer == uniqueIdentifier.eventId && fodselsnummer is FodselsnummerNumeric) {
                 UserEventIdEntry(
-                        fodselsnummer = Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer),
-                        eventId = EventIdFodselsnummer(fodselsnummer.longValue)
+                        fodselsnummer = fodselsnummer,
+                        eventId = EventIdFodselsnummer(uniqueIdentifier.eventId.toLong())
                 )
             } else {
                 UserEventIdEntry(
-                        fodselsnummer = Fodselsnummer.fromString(uniqueIdentifier.fodselsnummer),
+                        fodselsnummer = fodselsnummer,
                         eventId = EventIdParser.parseEventId(uniqueIdentifier.eventId)
                 )
             }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/FodselsnummerParser.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/parse/FodselsnummerParser.kt
@@ -1,0 +1,75 @@
+package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse
+
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.*
+
+object FodselsnummerParser {
+    private val FODSELSNUMMER_FORMAT = "^[0-3][0-9][0-1][0-9]{8}$".toRegex()
+    private val D_NUMMER_FORMAT = "^[4-7][0-9][0-1][0-9]{8}$".toRegex()
+    private val H_NUMMER_FORMAT = "^[0-3][0-9][4-5][0-9]{8}$".toRegex()
+
+    fun parse(fnrString: String): Fodselsnummer {
+
+        return when {
+            FODSELSNUMMER_FORMAT.matches(fnrString) -> parseAsFnr(fnrString)
+            D_NUMMER_FORMAT.matches(fnrString) -> parseAsDnr(fnrString)
+            H_NUMMER_FORMAT.matches(fnrString) -> parseAsHnr(fnrString)
+            else -> FodselsnummerPlainText(fnrString)
+        }
+    }
+
+    private fun parseAsFnr(fnrString: String): FodselsnummerNumeric {
+        val encoded = buildString(9) {
+            append(fnrString.month)
+            append(fnrString.day)
+            append(fnrString.year)
+            append(fnrString.id)
+        }
+
+        val backingValue = encoded.toInt()
+
+        return FodselsnummerNumeric(backingValue)
+    }
+
+    private fun parseAsDnr(fnrString: String): FodselsnummerDNummer {
+        val encoded = buildString(9) {
+            append(fnrString.month)
+            append(fnrString.day)
+            append(fnrString.year)
+            append(fnrString.id)
+        }
+
+        val backingValue = encoded.toInt()
+
+        return FodselsnummerDNummer(backingValue)
+    }
+
+    private fun parseAsHnr(fnrString: String): FodselsnummerHNummer {
+
+        val encoded = buildString(9) {
+            append(calculateMonthForHnr(fnrString.month))
+            append(fnrString.day)
+            append(fnrString.year)
+            append(fnrString.id)
+        }
+
+        val backingValue = encoded.toInt()
+
+        return FodselsnummerHNummer(backingValue)
+    }
+
+    private fun calculateMonthForHnr(monthSegment: CharSequence): String {
+        val offsetMonthAsInt = monthSegment.toString().toInt()
+
+        val trueMonthAsInt = offsetMonthAsInt - 40
+
+        return trueMonthAsInt.toString()
+    }
+
+    private val String.day: CharSequence get() = subSequence(0, 2)
+    private val String.month: CharSequence get() = subSequence(2, 4)
+    private val String.year: CharSequence get() = subSequence(4, 6)
+    private val String.id: CharSequence get() = subSequence(6, 9)
+
+
+}
+

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test
 internal class FodselsnummerTest {
     @Test
     fun `Should use numeric variable to store fodselsnummer if possible`() {
-        val fodselsnummerText = "01122212345"
-        val expected = 120122123
+        val fodselsnummerText = "12345612345"
+        val expected = 123456123
 
         val fodselsnummer = FodselsnummerParser.parse(fodselsnummerText)
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/metrics/periodic/reporter/metrics/kafka/topic/events/FodselsnummerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events
 
+import no.nav.personbruker.dittnav.metrics.periodic.reporter.metrics.kafka.topic.events.parse.FodselsnummerParser
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be in`
 import org.amshove.kluent.`should be instance of`
@@ -8,19 +9,20 @@ import org.junit.jupiter.api.Test
 internal class FodselsnummerTest {
     @Test
     fun `Should use numeric variable to store fodselsnummer if possible`() {
-        val fodselsnummerText = "123456"
+        val fodselsnummerText = "01122212345"
+        val expected = 120122123
 
-        val fodselsnummer = Fodselsnummer.fromString(fodselsnummerText)
+        val fodselsnummer = FodselsnummerParser.parse(fodselsnummerText)
 
         fodselsnummer `should be instance of` FodselsnummerNumeric::class
-        (fodselsnummer as FodselsnummerNumeric).longValue `should be equal to` fodselsnummerText.toLong()
+        (fodselsnummer as FodselsnummerNumeric).encodedValue `should be equal to` expected
     }
 
     @Test
     fun `Should use string variable to store fodselsnummer it is not possible to parse as number`() {
         val fodselsnummerText = "abc123"
 
-        val fodselsnummer = Fodselsnummer.fromString(fodselsnummerText)
+        val fodselsnummer = FodselsnummerParser.parse(fodselsnummerText)
 
         fodselsnummer `should be instance of` FodselsnummerPlainText::class
         (fodselsnummer as FodselsnummerPlainText).stringValue `should be equal to` fodselsnummerText
@@ -28,10 +30,10 @@ internal class FodselsnummerTest {
 
     @Test
     fun `Should work as expected in sets`() {
-        val fodselsnummerNumeric = Fodselsnummer.fromString("123")
-        val fodselsnummerNumericDuplicate = Fodselsnummer.fromString("123")
-        val fodselsnummerString = Fodselsnummer.fromString("abc")
-        val fodselsnummerStringDuplicate = Fodselsnummer.fromString("abc")
+        val fodselsnummerNumeric = FodselsnummerParser.parse("123")
+        val fodselsnummerNumericDuplicate = FodselsnummerParser.parse("123")
+        val fodselsnummerString = FodselsnummerParser.parse("abc")
+        val fodselsnummerStringDuplicate = FodselsnummerParser.parse("abc")
 
         val set = HashSet<Fodselsnummer>()
 


### PR DESCRIPTION
Reduser minnebruk ved 2 punkter:

1. Bruker et `UnifiedSet` fra eclipse-collections som har bruker mindre minne per innslag enn HashSet. I prod sparer minst 900MB.

2. Trikser litt med hvordan vi holder på fnr. Hvis vi antar at alle fnr vi får er gyldige, kan vi unnlate å holde på de siste to sifrene, ettersom dette er kontrollsiffer. Dette gjør at vi kan holde alle unike, gyldige fnr i en Int i stedet for Long. Dette sparer  i underkant av 200 MB. 